### PR TITLE
fix: 修复缓冲区截断导致的断网 & 修复重启时无限循环

### DIFF
--- a/esurfingclient/esurfing/inc/States.h
+++ b/esurfingclient/esurfing/inc/States.h
@@ -13,9 +13,9 @@
 #define USER_AGENT_LEN 32
 #define CLIENT_ID_LEN 40
 #define HOST_NAME_LEN 16
-#define KEEP_URL_LEN 80
-#define TERM_URL_LEN 80
-#define AUTH_URL_LEN 80
+#define KEEP_URL_LEN 256
+#define TERM_URL_LEN 256
+#define AUTH_URL_LEN 256
 #define MAC_ADDR_LEN 20
 #define ALGO_ID_LEN 37
 #define TICKET_LEN 40

--- a/esurfingclient/esurfing/inc/States.h
+++ b/esurfingclient/esurfing/inc/States.h
@@ -9,7 +9,7 @@
 
 #define SCHOOL_NETWORK_SYMBOL 8
 
-#define TICKET_URL_LEN 256
+#define TICKET_URL_LEN 512
 #define USER_AGENT_LEN 32
 #define CLIENT_ID_LEN 40
 #define HOST_NAME_LEN 16
@@ -27,7 +27,7 @@
 #define IP_LEN 16
 #define IF_LEN 16
 
-#define LAST_LOCATION_LEN 256
+#define LAST_LOCATION_LEN 512
 
 /** @brief 认证配置 */
 typedef struct

--- a/esurfingclient/esurfing/src/DialerClient.c
+++ b/esurfingclient/esurfing/src/DialerClient.c
@@ -685,7 +685,7 @@ void work()
             sleep_ms(1000);
             break;
         }
-    } while (status != REQUEST_REDIRECT);
+    } while (status != REQUEST_REDIRECT && status != REQUEST_SUCCESS);
 
     /**
      * 根据配置数创建相应数量的线程


### PR DESCRIPTION
## 修复内容

### 1. Location/Ticket URL 截断修复
- LAST_LOCATION_LEN: 256 -> 512
- TICKET_URL_LEN: 256 -> 512

### 2. Keep/Term/Auth URL 缓冲区修复
- KEEP_URL_LEN: 80 -> 256
- TERM_URL_LEN: 80 -> 256
- AUTH_URL_LEN: 80 -> 256

### 3. 程序重启时无限循环修复
- work() 初始循环: REQUEST_SUCCESS 时也退出