### PR TITLE
feat(NetClient): use http://223.5.5.5 for connectivity check

### DIFF
--- a/esurfingclient/main/inc/NetClient.h
+++ b/esurfingclient/main/inc/NetClient.h
@@ -9,7 +9,8 @@ typedef enum {
     REQUEST_WARN = 2,
     REQUEST_HAVE_RES = 200,
     REQUEST_SUCCESS = 204,
-    REQUEST_REDIRECT = 302
+    REQUEST_REDIRECT = 302,
+    REQUEST_NOT_FOUND = 404
 } NetworkStatus;
 
 typedef struct {

--- a/esurfingclient/main/src/NetClient.c
+++ b/esurfingclient/main/src/NetClient.c
@@ -27,8 +27,7 @@
 
 static const char s_req_content_type[] = "Content-Type: application/x-www-form-urlencoded";
 static const char s_req_accept[] = "Accept: text/html,text/xml,application/xhtml+xml,application/x-javascript,*/*";
-static const char s_generate_url[] = "http://connect.rom.miui.com/generate_204";
-static const char s_backup_generate_url[] = "http://192.0.2.1";
+static const char s_generate_url[] = "http://223.5.5.5";
 
 static char s_school_id[SCHOOL_ID_LENGTH];
 static char s_domain[DOMAIN_LENGTH];
@@ -494,6 +493,12 @@ http_resp_t get(const char* url)
         resp.status = REQUEST_SUCCESS;
         return resp;
     }
+    if (resp_code == 404)
+    {
+        LOG_VERBOSE("资源不存在, 响应码: 404");
+        resp.status = REQUEST_NOT_FOUND;
+        return resp;
+    }
 
     LOG_ERROR("HTTP 响应错误, 响应码: %ld", resp_code);
     resp.status = REQUEST_ERROR;
@@ -502,16 +507,8 @@ http_resp_t get(const char* url)
 
 NetworkStatus check_network_status()
 {
-    http_resp_t resp = get(s_generate_url);
-    if (resp.curl_code == CURLE_COULDNT_RESOLVE_HOST)
-    {
-        LOG_WARN("DNS 解析错误, 使用备用超时方案重试");
-        resp = get(s_backup_generate_url);
-        if (resp.status == REQUEST_WARN)
-        {
-            resp.status = REQUEST_SUCCESS;
-        }
-    }
+    const http_resp_t resp = get(s_generate_url);
+    if (resp.status == REQUEST_NOT_FOUND) return REQUEST_SUCCESS; // 404代表已连接至互联网
     return resp.status;
 }
 
@@ -530,15 +527,7 @@ NetworkStatus get_last_location()
     do
     {
         resp = get(s_generate_url); // 检测响应码
-        if (resp.curl_code == CURLE_COULDNT_RESOLVE_HOST)
-        {
-            LOG_WARN("DNS 解析错误, 使用备用超时方案重试");
-            resp = get(s_backup_generate_url);
-            if (resp.status == REQUEST_WARN)
-            {
-                resp.status = REQUEST_SUCCESS;
-            }
-        }
+        if (resp.status == REQUEST_NOT_FOUND) resp.status = REQUEST_SUCCESS; // 404 代表已连接至互联网
         switch (resp.status)
         {
         case REQUEST_REDIRECT:


### PR DESCRIPTION
联网检测的 URL 换成 `http://223.5.5.5`，并把 HTTP 404 视为已连接至互联网。同时删掉原有的 DNS 解析失败兜底逻辑

## 改动原因
大部分用户网络环境复杂，例如未联网时无法通过DoH解析IP，连接走代理等情况

<img width="1307" height="1106" alt="image" src="https://github.com/user-attachments/assets/f93dbc76-dfe2-4f25-962d-60dc7962232c" />


`223.5.5.5` 是纯 IP，完全不经过 DNS，从根本上避开了这个问题。实测它在 80 端口直接返回 `404 Not Found`，不会跳转到 HTTPS，也不会返回 200/204，所以返回 404 就是已联网

不再有 DNS 解析这一步，`CURLE_COULDNT_RESOLVE_HOST` 分支已经是死代码，一并删除

## 具体改动

- `s_generate_url` 改为 `http://223.5.5.5`，删除 `s_backup_generate_url`。
- `NetworkStatus` 新增 `REQUEST_NOT_FOUND = 404`；`get()` 单独归类 404，不再落到通用的 HTTP 错误分支
- `check_network_status()` 与 `get_last_location()` 把 `REQUEST_NOT_FOUND` 当作 `REQUEST_SUCCESS` 处理
- 删除两处 `CURLE_COULDNT_RESOLVE_HOST` 的兜底重试

## 设计考量

**404 只在 `get()` 里处理，`post()` 保持原样。** `post()` 走的是认证接口，那边返回 404 属于真正的异常，仍然应该是 `REQUEST_ERROR`

## 测试情况

本地已成功完成校园网认证并正常发送心跳包

<img width="1062" height="341" alt="image" src="https://github.com/user-attachments/assets/01a93e5a-fa07-4338-8484-6254493bbfd9" />



https://github.com/Suzu-86/ESurfingClient-CVersion/actions/runs/33328771195