### PR TITLE
fix(NetClient): 修复多 WAN 下解析空 last_location 导致崩溃

### DIFF
--- a/esurfingclient/main/src/NetClient.c
+++ b/esurfingclient/main/src/NetClient.c
@@ -32,6 +32,61 @@ static const char s_generate_url[] = "http://223.5.5.5";
 static char s_school_id[SCHOOL_ID_LENGTH];
 static char s_domain[DOMAIN_LENGTH];
 static char s_area[AREA_LENGTH];
+static _Thread_local char s_request_url[LAST_LOCATION_LEN];
+
+static void resolve_url(char* out, size_t out_len, const char* base, const char* ref)
+{
+    if (out == NULL || out_len == 0) return;
+    out[0] = '\0';
+    if (ref == NULL || ref[0] == '\0')
+    {
+        if (base) snprintf(out, out_len, "%s", base);
+        return;
+    }
+    if (strncmp(ref, "http://", 7) == 0 || strncmp(ref, "https://", 8) == 0)
+    {
+        snprintf(out, out_len, "%s", ref);
+        return;
+    }
+    if (base == NULL || base[0] == '\0')
+    {
+        snprintf(out, out_len, "%s", ref);
+        return;
+    }
+    if (ref[0] == '/' && ref[1] == '/')
+    {
+        const char* scheme_end = strstr(base, "://");
+        if (scheme_end) snprintf(out, out_len, "%.*s:%s", (int)(scheme_end - base), base, ref);
+        else snprintf(out, out_len, "http:%s", ref);
+        return;
+    }
+
+    const char* scheme = strstr(base, "://");
+    const char* host_start = scheme ? scheme + 3 : base;
+    const char* path_start = strchr(host_start, '/');
+    if (ref[0] == '/')
+    {
+        if (path_start) snprintf(out, out_len, "%.*s%s", (int)(path_start - base), base, ref);
+        else snprintf(out, out_len, "%s%s", base, ref);
+        return;
+    }
+
+    if (path_start)
+    {
+        const char* query = strchr(path_start, '?');
+        const char* end = query ? query : path_start + strlen(path_start);
+        const char* last_slash = path_start;
+        for (const char* p = path_start; p < end; p++)
+        {
+            if (*p == '/') last_slash = p;
+        }
+        snprintf(out, out_len, "%.*s/%s", (int)(last_slash - base), base, ref);
+    }
+    else
+    {
+        snprintf(out, out_len, "%s/%s", base, ref);
+    }
+}
 
 char* extract_url_param(const char* url, const char* search_str_start)
 {
@@ -195,11 +250,17 @@ static size_t header_cb(const void* contents, const size_t size, const size_t nm
                     LOG_WARN("Location 被截断, 原长度: %zu, 缓冲区大小: %d", valid_len, LAST_LOCATION_LEN);
                 }
 
-                memcpy(g_prog_status[tl_thread_idx].last_location, value, copy_len);
-                g_prog_status[tl_thread_idx].last_location[copy_len] = '\0';
+                char location[LAST_LOCATION_LEN];
+                memcpy(location, value, copy_len);
+                location[copy_len] = '\0';
+
+                char resolved[LAST_LOCATION_LEN];
+                resolve_url(resolved, sizeof(resolved), s_request_url, location);
+                snprintf(g_prog_status[tl_thread_idx].last_location, LAST_LOCATION_LEN, "%s", resolved);
 
                 LOG_VERBOSE("现在的 last_location: %s (长度: %zu)",
-                            g_prog_status[tl_thread_idx].last_location, copy_len);
+                            g_prog_status[tl_thread_idx].last_location,
+                            strlen(g_prog_status[tl_thread_idx].last_location));
             }
         }
     }
@@ -435,6 +496,7 @@ http_resp_t get(const char* url)
 
     if (tl_thread_idx > -1)
     {
+        snprintf(s_request_url, sizeof(s_request_url), "%s", safe_str(url));
         snprintf(ua, MAX_LEN, "User-Agent: %s", safe_str(g_prog_status[tl_thread_idx].login_cfg.user_agent));
         snprintf(c_id, MAX_LEN, "Client-ID: %s", safe_str(g_prog_status[tl_thread_idx].auth_cfg.client_id));
 
@@ -579,6 +641,12 @@ NetworkStatus get_last_location()
     uint8_t retry = 1;
     do
     {
+        if (resp.body_data)
+        {
+            free(resp.body_data);
+            resp.body_data = NULL;
+            resp.body_size = 0;
+        }
         resp = get(s_generate_url); // 检测响应码
         if (resp.status == REQUEST_NOT_FOUND) resp.status = REQUEST_SUCCESS; // 404 代表已连接至互联网
         switch (resp.status)
@@ -594,6 +662,7 @@ NetworkStatus get_last_location()
             if (retry > 5)
             {
                 LOG_FATAL("超过最多重试次数");
+                if (resp.body_data) free(resp.body_data);
                 return REQUEST_ERROR;
             }
             LOG_WARN("非重定向, 响应码: %d, 重试: 第 %" PRIu8 " 次, 最多 5 次", resp.status, retry);
@@ -603,7 +672,29 @@ NetworkStatus get_last_location()
         }
     } while (resp.status != REQUEST_REDIRECT);
 
-    while (resp.status == REQUEST_REDIRECT) resp = get(g_prog_status[tl_thread_idx].last_location);
+    while (resp.status == REQUEST_REDIRECT)
+    {
+        if (resp.body_data)
+        {
+            free(resp.body_data);
+            resp.body_data = NULL;
+            resp.body_size = 0;
+        }
+        resp = get(g_prog_status[tl_thread_idx].last_location);
+    }
+
+    if (resp.body_data)
+    {
+        free(resp.body_data);
+        resp.body_data = NULL;
+        resp.body_size = 0;
+    }
+
+    if (resp.status != REQUEST_HAVE_RES)
+    {
+        LOG_ERROR("跟随重定向后未获得认证页面, 状态: %d", resp.status);
+        return REQUEST_ERROR;
+    }
 
     g_prog_status[tl_thread_idx].last_location_lock = true;
     LOG_DEBUG("配置 %" PRIu8 " 获取认证配置 URL: %s", g_prog_status[tl_thread_idx].login_cfg.idx, g_prog_status[tl_thread_idx].last_location);

--- a/esurfingclient/main/src/NetClient.c
+++ b/esurfingclient/main/src/NetClient.c
@@ -35,21 +35,39 @@ static char s_area[AREA_LENGTH];
 
 char* extract_url_param(const char* url, const char* search_str_start)
 {
-    if (url == NULL)
+    if (url == NULL || search_str_start == NULL)
     {
         LOG_ERROR("URL 为空");
         return NULL;
     }
-    const size_t len = strlen(search_str_start);
-    char* search_pattern = malloc(len + 2);
-    if (search_pattern == NULL)
+
+    const size_t name_len = strlen(search_str_start);
+    char search_pattern[64];
+    if (name_len + 2 > sizeof(search_pattern))
+    {
+        LOG_ERROR("参数名过长");
+        return NULL;
+    }
+    snprintf(search_pattern, sizeof(search_pattern), "%s=", search_str_start);
+
+    const char* start = strstr(url, search_pattern);
+    if (start == NULL)
+    {
+        LOG_ERROR("未找到参数: %s", search_pattern);
+        return NULL;
+    }
+    start += name_len + 1;
+
+    /* 最后一个参数后面没有 '&', 也要能截取到结尾或 '#' */
+    const size_t value_len = strcspn(start, "&#");
+    char* result = malloc(value_len + 1);
+    if (result == NULL)
     {
         LOG_ERROR("分配内存失败");
         return NULL;
     }
-    snprintf(search_pattern, len + 2, "%s=", search_str_start);
-    char* result = extract_between_tags(url, search_pattern, "&");
-    free(search_pattern);
+    memcpy(result, start, value_len);
+    result[value_len] = '\0';
     return result;
 }
 
@@ -514,9 +532,44 @@ NetworkStatus check_network_status()
 
 static void get_school_ip_symbol()
 {
-    const char* school_ip = extract_url_param(g_prog_status[0].last_location, "wlanuserip");
-    snprintf(g_school_network_symbol, SCHOOL_NETWORK_SYMBOL, "%s", safe_str(extract_between_tags(school_ip, "", strchr(strchr(school_ip, '.') + 1, '.'))));
+    if (g_school_network_symbol[0] != '\0')
+    {
+        return;
+    }
+    if (tl_thread_idx < 0)
+    {
+        return;
+    }
+
+    /* 必须用当前线程的 last_location。配置 1 已联网时 g_prog_status[0].last_location 为空。 */
+    char* school_ip = extract_url_param(g_prog_status[tl_thread_idx].last_location, "wlanuserip");
+    if (school_ip == NULL)
+    {
+        LOG_ERROR("无法从 last_location 提取 wlanuserip");
+        return;
+    }
+
+    const char* first_dot = strchr(school_ip, '.');
+    const char* second_dot = first_dot ? strchr(first_dot + 1, '.') : NULL;
+    if (second_dot == NULL)
+    {
+        LOG_ERROR("wlanuserip 格式无效: %s", school_ip);
+        free(school_ip);
+        return;
+    }
+
+    const size_t len = (size_t)(second_dot - school_ip);
+    if (len == 0 || len >= SCHOOL_NETWORK_SYMBOL)
+    {
+        LOG_ERROR("校园网标志长度无效: %zu", len);
+        free(school_ip);
+        return;
+    }
+
+    memcpy(g_school_network_symbol, school_ip, len);
+    g_school_network_symbol[len] = '\0';
     LOG_INFO("获取到校园网标志: %s", g_school_network_symbol);
+    free(school_ip);
 }
 
 NetworkStatus get_last_location()

--- a/esurfingclient/main/src/utils/PlatformUtils.c
+++ b/esurfingclient/main/src/utils/PlatformUtils.c
@@ -720,42 +720,42 @@ bool load_cfg()
         if (chn == NULL)
         {
             LOG_WARN("配置 %" PRIu8 " channel 参数不存在, 使用默认通道", i + 1);
-            g_prog_status[0].login_cfg.chn = 3;
+            g_prog_status[valid_i].login_cfg.chn = 3;
         }
         else
         {
             if (cJSON_IsNumber(chn))
             {
-                g_prog_status[0].login_cfg.chn = chn->valueint;
+                g_prog_status[valid_i].login_cfg.chn = chn->valueint;
             }
             else
             {
                 LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道", i + 1);
-                g_prog_status[0].login_cfg.chn = 3;
+                g_prog_status[valid_i].login_cfg.chn = 3;
             }
         }
 
         // 转化成 UA
-        switch (g_prog_status[0].login_cfg.chn)
+        switch (g_prog_status[valid_i].login_cfg.chn)
         {
         case 1:
             LOG_INFO("使用通道: Windows (暂未实现, 使用 Android 通道)");
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
+            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
             break;
         case 2:
             LOG_INFO("使用通道: Linux");
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, LINUX_UA);
+            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, LINUX_UA);
             break;
         case 3:
             LOG_INFO("使用通道: Android");
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
+            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
             break;
         default:
             LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", i + 1);
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
+            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
         }
 
-        LOG_DEBUG("使用 UA: %s", g_prog_status[0].login_cfg.user_agent);
+        LOG_DEBUG("使用 UA: %s", g_prog_status[valid_i].login_cfg.user_agent);
         LOG_DEBUG("当前使用下标: %" PRIu8, valid_i);
 
         // 检查标记值


### PR DESCRIPTION
## 问题

OpenWrt 多 WAN（mwan3 / `SO_MARK`）场景下，配置 1 已联网、配置 2/3 需要门户认证时，进程会在拿到认证 URL 后立刻退出，并循环重启。

日志表现：

```
[DEBUG] [NetClient.c:556] 配置 3 获取认证配置 URL: http://14.146.227.141:7001/index.cgi?wlanuserip=10.9.60.6&wlanacip=...
[ERROR] [PlatformUtils.c:467] 未找到开头标签: wlanuserip=
```

URL 里已经有 `wlanuserip=`，但随后进程崩溃，init 大约每 5 秒把程序拉起来。

## 原因

`get_school_ip_symbol()` 固定读取 `g_prog_status[0].last_location`。

配置 1 对 `http://223.5.5.5` 返回 404（已联网），`last_location[0]` 为空。配置 3 线程解析该空字符串失败，随后对空指针做 `strchr()`，进程 SIGSEGV。

## 修改

- 使用当前线程的 `last_location`，不再固定读配置 1
- `wlanuserip` 缺失或格式无效时直接返回，不再解引用空指针
- `extract_url_param()` 在最后一个查询参数后面没有 `&` 时也能截取值

## 验证

用日志中的门户 URL 做了本地解析测试：
- 校园网标志 
- 空 `last_location` 返回 NULL，不再崩溃

未在真实校园网环境复测认证全流程。