### PR TITLE
feat: 增加 iOS / macOS 认证通道

### DIFF
--- a/esurfingclient/main/CMakeLists.txt
+++ b/esurfingclient/main/CMakeLists.txt
@@ -65,6 +65,8 @@ if (__OPENWRT__)
             src/cipher/algo/android/snow3g_variant_android.c
             src/cipher/algo/android/tea_triple_cbc_android.c
             src/cipher/algo/android/tea_triple_ecb_android.c
+            src/cipher/algo/ios/ios_zsm.c
+            src/cipher/algo/ios/lzma/LzmaDec.c
             src/cipher/algo/linux/mod_xtea_cbc_triple_linux.c
             src/cipher/algo/linux/des_ecb_six_linux.c
             src/cipher/algo/linux/desede_cbc_linux.c
@@ -95,6 +97,8 @@ else ()
             src/cipher/algo/android/snow3g_variant_android.c
             src/cipher/algo/android/tea_triple_cbc_android.c
             src/cipher/algo/android/tea_triple_ecb_android.c
+            src/cipher/algo/ios/ios_zsm.c
+            src/cipher/algo/ios/lzma/LzmaDec.c
             src/cipher/algo/linux/mod_xtea_cbc_triple_linux.c
             src/cipher/algo/linux/des_ecb_six_linux.c
             src/cipher/algo/linux/desede_cbc_linux.c
@@ -134,6 +138,7 @@ endif ()
 
 target_include_directories(ESurfingClient PRIVATE
         ${CMAKE_SOURCE_DIR}/inc
+        ${CMAKE_SOURCE_DIR}/src/cipher/algo/ios/lzma
 )
 
 if (WIN32)

--- a/esurfingclient/main/inc/States.h
+++ b/esurfingclient/main/inc/States.h
@@ -12,7 +12,8 @@
 #define TICKET_URL_LEN 512
 #define USER_AGENT_LEN 32
 #define CLIENT_ID_LEN 40
-#define HOST_NAME_LEN 16
+#define HOST_NAME_LEN 32
+#define OSTAG_LEN 32
 #define KEEP_URL_LEN 256
 #define TERM_URL_LEN 256
 #define AUTH_URL_LEN 256
@@ -37,6 +38,8 @@ typedef struct
     char client_id[CLIENT_ID_LEN];
     /** @brief 主机名 */
     char host_name[HOST_NAME_LEN];
+    /** @brief 系统标识 */
+    char ostag[OSTAG_LEN];
     /** @brief 心跳 URL */
     char keep_url[KEEP_URL_LEN];
     /** @brief 登出 URL */

--- a/esurfingclient/main/inc/cipher/IosZsm.h
+++ b/esurfingclient/main/inc/cipher/IosZsm.h
@@ -8,7 +8,7 @@
 /**
  * 从 iOS PacketTunnel ZSM 解包密钥并初始化加解密工厂.
  * ZSM 不是 Android/Linux 那种 UUID→硬编码密钥表, 正文是 TEA + LZMA 后的 JS,
- * 密钥在 cdckey/cdciv, 算法由 JS 里的 cdy(type, ...) 决定.
+ * 密钥在 cdckey/cdciv, 算法由 JS 的 var codex = 0xNN 或 cdy(type, ...) 决定.
  *
  * @param data ZSM 原始字节
  * @param length ZSM 长度

--- a/esurfingclient/main/inc/cipher/IosZsm.h
+++ b/esurfingclient/main/inc/cipher/IosZsm.h
@@ -1,0 +1,20 @@
+#ifndef ESURFINGCLIENT_IOSZSM_H
+#define ESURFINGCLIENT_IOSZSM_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * 从 iOS PacketTunnel ZSM 解包密钥并初始化加解密工厂.
+ * ZSM 不是 Android/Linux 那种 UUID→硬编码密钥表, 正文是 TEA + LZMA 后的 JS,
+ * 密钥在 cdckey/cdciv, 算法由 JS 里的 cdy(type, ...) 决定.
+ *
+ * @param data ZSM 原始字节
+ * @param length ZSM 长度
+ * @param algo_id_out 可选, 写入头部 str2 的 Algo-ID (大写 UUID)
+ * @return 是否成功
+ */
+bool init_ios_cipher_from_zsm(const uint8_t* data, size_t length, char* algo_id_out);
+
+#endif

--- a/esurfingclient/main/inc/cipher/IosZsm.h
+++ b/esurfingclient/main/inc/cipher/IosZsm.h
@@ -17,4 +17,11 @@
  */
 bool init_ios_cipher_from_zsm(const uint8_t* data, size_t length, char* algo_id_out);
 
+/**
+ * 判断 ticket 响应是否为 PacketTunnel IZsmModLoad 动态模块.
+ * 头部是两个 Pascal 字符串, 随后 LZMA packed type nibble == 2.
+ * 这种 ZSM 的 AID 不在 Android/Linux CipherFactory 里.
+ */
+bool looks_like_ios_zsm(const uint8_t* data, size_t length);
+
 #endif

--- a/esurfingclient/main/portal/assets/js/main.js
+++ b/esurfingclient/main/portal/assets/js/main.js
@@ -21,6 +21,16 @@ document.addEventListener('alpine:init', () => {
             .then(r => r.json())
             .then(data => {
                 this.configs = data;
+                if (this.configs.accounts && this.configs.accounts[0]) {
+                    const ch = this.configs.accounts[0].channel;
+                    if (ch === 4 || ch === '4' || ch === 'ios' || ch === 'iphone') {
+                        this.configs.accounts[0].channel = 'ios';
+                    } else if (ch === 2 || ch === '2' || ch === 'pc' || ch === 'linux') {
+                        this.configs.accounts[0].channel = 'pc';
+                    } else {
+                        this.configs.accounts[0].channel = 'phone';
+                    }
+                }
             })
             .catch(error => {
                 // 处理错误，例如显示通知

--- a/esurfingclient/main/portal/assets/js/main.js
+++ b/esurfingclient/main/portal/assets/js/main.js
@@ -23,7 +23,9 @@ document.addEventListener('alpine:init', () => {
                 this.configs = data;
                 if (this.configs.accounts && this.configs.accounts[0]) {
                     const ch = this.configs.accounts[0].channel;
-                    if (ch === 4 || ch === '4' || ch === 'ios' || ch === 'iphone') {
+                    if (ch === 5 || ch === '5' || ch === 'macos' || ch === 'mac' || ch === 'osx') {
+                        this.configs.accounts[0].channel = 'macos';
+                    } else if (ch === 4 || ch === '4' || ch === 'ios' || ch === 'iphone') {
                         this.configs.accounts[0].channel = 'ios';
                     } else if (ch === 2 || ch === '2' || ch === 'pc' || ch === 'linux') {
                         this.configs.accounts[0].channel = 'pc';

--- a/esurfingclient/main/portal/index.html
+++ b/esurfingclient/main/portal/index.html
@@ -244,6 +244,7 @@
                   <select class="select" x-model="accounts[0].channel">
                     <option value="phone">phone</option>
                     <option value="pc">pc</option>
+                    <option value="ios">ios</option>
                   </select>
                   <span class="label">选择账号的认证通道</span>
                 </fieldset>

--- a/esurfingclient/main/portal/index.html
+++ b/esurfingclient/main/portal/index.html
@@ -245,6 +245,7 @@
                     <option value="phone">phone</option>
                     <option value="pc">pc</option>
                     <option value="ios">ios</option>
+                    <option value="macos">macos</option>
                   </select>
                   <span class="label">选择账号的认证通道</span>
                 </fieldset>

--- a/esurfingclient/main/src/DialerClient.c
+++ b/esurfingclient/main/src/DialerClient.c
@@ -375,9 +375,12 @@ static bool extract_algo_id_from_zsm(const bytes_t zsm, char* algo_id)
 static bool load_cipher(const bytes_t zsm)
 {
     char algo_id[ALGO_ID_LEN];
+    const uint8_t chn = g_prog_status[tl_thread_idx].login_cfg.chn;
+    const bool ios_module = looks_like_ios_zsm(zsm.data, zsm.length);
 
     LOG_DEBUG("load 函数入口检查, 使用配置: %" PRIu8 ", 下标: %" PRIu8, g_prog_status[tl_thread_idx].login_cfg.idx, tl_thread_idx);
-    LOG_DEBUG("接收到的 zsm 数据长度: %zu", zsm.length);
+    LOG_INFO("当前通道: %" PRIu8 ", ZSM 长度: %zu, iOS 动态模块: %s",
+             chn, zsm.length, ios_module ? "是" : "否");
     if (zsm.data == NULL || zsm.length == 0) // 检查 zsm 数据是否为空, 为空则返回 false
     {
         LOG_ERROR("无效的 zsm 数据");
@@ -385,35 +388,52 @@ static bool load_cipher(const bytes_t zsm)
     }
 
     /**
-     * iOS 通道的密钥在 ZSM 解包后的 JS (cdckey/cdciv + cdy) 里,
-     * 不能按 Android/Linux 那样用头部 UUID 去查 CipherFactory.
+     * iOS PacketTunnel 的 ZSM 是 TEA+LZMA 后的 JS 模块, 头部 UUID 只是模块 ID,
+     * 不在 Android/Linux CipherFactory 里. 按内容识别, 避免 LuCI 仍是 phone/pc
+     * 时把 iOS ZSM 误送去查硬编码密钥表, 报 "未知 Algo-ID".
+     * 通道号只决定 UA/主机名, 不决定密钥解包方式.
      */
-    if (g_prog_status[tl_thread_idx].login_cfg.chn == 4)
+    if (chn == 4 || ios_module)
     {
+        if (chn != 4)
+        {
+            LOG_WARN("通道不是 iOS, 但 ticket 返回了 iOS 动态 ZSM, 按动态密钥解包, UA 不变");
+        }
         if (init_ios_cipher_from_zsm(zsm.data, zsm.length, algo_id) == false)
         {
-            LOG_ERROR("iOS 通道无法从 ZSM 解包出密钥 (长度 %zu)", zsm.length);
-            return false;
+            LOG_ERROR("无法按 iOS ZSM 解包出密钥 (长度 %zu, 通道 %" PRIu8 ")", zsm.length, chn);
+            if (chn == 4)
+            {
+                return false;
+            }
+            LOG_WARN("iOS ZSM 解包失败, 回退到 CipherFactory");
+        }
+        else
+        {
+            snprintf(g_prog_status[tl_thread_idx].auth_cfg.algo_id, ALGO_ID_LEN, "%s", safe_str(algo_id));
+            LOG_DEBUG("全局 AlgoID 已更新: %s", g_prog_status[tl_thread_idx].auth_cfg.algo_id);
+            return true;
         }
     }
-    else
-    {
-        if (extract_algo_id_from_zsm(zsm, algo_id) == false)
-        {
-            LOG_ERROR("无法从 ZSM 中提取 Algo-ID (长度 %zu)", zsm.length);
-            return false;
-        }
-        LOG_INFO("Algo ID: %s", algo_id);
 
-        /**
-         * 初始化加解密工厂
-         * 如果失败, 返回 false
-         */
-        if (init_cipher(algo_id) == false)
+    if (extract_algo_id_from_zsm(zsm, algo_id) == false)
+    {
+        LOG_ERROR("无法从 ZSM 中提取 Algo-ID (长度 %zu)", zsm.length);
+        return false;
+    }
+    LOG_INFO("Algo ID: %s", algo_id);
+
+    if (init_cipher(algo_id) == false)
+    {
+        LOG_WARN("CipherFactory 没有 Algo-ID %s, 尝试按 iOS 动态模块解包", algo_id);
+        if (init_ios_cipher_from_zsm(zsm.data, zsm.length, algo_id))
         {
-            LOG_ERROR("未知 Algo-ID: %s, 当前通道没有对应密钥", algo_id);
-            return false;
+            snprintf(g_prog_status[tl_thread_idx].auth_cfg.algo_id, ALGO_ID_LEN, "%s", safe_str(algo_id));
+            LOG_DEBUG("全局 AlgoID 已更新: %s", g_prog_status[tl_thread_idx].auth_cfg.algo_id);
+            return true;
         }
+        LOG_ERROR("未知 Algo-ID: %s, 当前通道没有对应密钥", algo_id);
+        return false;
     }
     snprintf(g_prog_status[tl_thread_idx].auth_cfg.algo_id, ALGO_ID_LEN, "%s", safe_str(algo_id)); // 将 algo_id 填入认证配置中
     LOG_DEBUG("全局 AlgoID 已更新: %s", g_prog_status[tl_thread_idx].auth_cfg.algo_id);
@@ -432,9 +452,17 @@ static bool init_session()
     LOG_DEBUG("init_session 函数入口检查, 使用配置: %" PRIu8 ", 下标: %" PRIu8, g_prog_status[tl_thread_idx].login_cfg.idx, tl_thread_idx);
 
     /**
-     * 使用初始 algo_id 向 ticket_url POST 获取数据
+     * 向 ticket_url POST 获取 ZSM.
+     * iOS PacketTunnel 在没有本地模块时 encodeData 返回空 body, 只带
+     * Algo-ID: 00000000-... . Android/Linux 仍 POST 全 0 UUID.
      */
-    const http_resp_t result = post(g_prog_status[tl_thread_idx].auth_cfg.ticket_url, g_prog_status[tl_thread_idx].auth_cfg.algo_id);
+    const char* ticket_body = g_prog_status[tl_thread_idx].auth_cfg.algo_id;
+    if (g_prog_status[tl_thread_idx].login_cfg.chn == 4)
+    {
+        ticket_body = "";
+        LOG_INFO("iOS 通道首次拉取 ZSM 使用空 POST");
+    }
+    const http_resp_t result = post(g_prog_status[tl_thread_idx].auth_cfg.ticket_url, ticket_body);
     if (result.status != REQUEST_HAVE_RES || result.body_size == 0 || result.body_data == NULL) // 响应错误或无响应数据, 则返回 false
     {
         LOG_ERROR("初始化会话失败");

--- a/esurfingclient/main/src/DialerClient.c
+++ b/esurfingclient/main/src/DialerClient.c
@@ -1,4 +1,5 @@
 #include "cipher/CipherInterface.h"
+#include "cipher/IosZsm.h"
 #include "utils/PlatformUtils.h"
 #include "utils/Shutdown.h"
 #include "utils/Logger.h"
@@ -383,21 +384,36 @@ static bool load_cipher(const bytes_t zsm)
         return false;
     }
 
-    if (extract_algo_id_from_zsm(zsm, algo_id) == false)
-    {
-        LOG_ERROR("无法从 ZSM 中提取 Algo-ID (长度 %zu)", zsm.length);
-        return false;
-    }
-    LOG_INFO("Algo ID: %s", algo_id);
-
     /**
-     * 初始化加解密工厂
-     * 如果失败, 返回 false
+     * iOS 通道的密钥在 ZSM 解包后的 JS (cdckey/cdciv + cdy) 里,
+     * 不能按 Android/Linux 那样用头部 UUID 去查 CipherFactory.
      */
-    if (init_cipher(algo_id) == false)
+    if (g_prog_status[tl_thread_idx].login_cfg.chn == 4)
     {
-        LOG_ERROR("未知 Algo-ID: %s, 当前通道没有对应密钥", algo_id);
-        return false;
+        if (init_ios_cipher_from_zsm(zsm.data, zsm.length, algo_id) == false)
+        {
+            LOG_ERROR("iOS 通道无法从 ZSM 解包出密钥 (长度 %zu)", zsm.length);
+            return false;
+        }
+    }
+    else
+    {
+        if (extract_algo_id_from_zsm(zsm, algo_id) == false)
+        {
+            LOG_ERROR("无法从 ZSM 中提取 Algo-ID (长度 %zu)", zsm.length);
+            return false;
+        }
+        LOG_INFO("Algo ID: %s", algo_id);
+
+        /**
+         * 初始化加解密工厂
+         * 如果失败, 返回 false
+         */
+        if (init_cipher(algo_id) == false)
+        {
+            LOG_ERROR("未知 Algo-ID: %s, 当前通道没有对应密钥", algo_id);
+            return false;
+        }
     }
     snprintf(g_prog_status[tl_thread_idx].auth_cfg.algo_id, ALGO_ID_LEN, "%s", safe_str(algo_id)); // 将 algo_id 填入认证配置中
     LOG_DEBUG("全局 AlgoID 已更新: %s", g_prog_status[tl_thread_idx].auth_cfg.algo_id);

--- a/esurfingclient/main/src/DialerClient.c
+++ b/esurfingclient/main/src/DialerClient.c
@@ -6,6 +6,7 @@
 #include "NetClient.h"
 #include "States.h"
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -261,10 +262,120 @@ static bool get_ticket()
     return true;
 }
 
+static bool is_uuid_text(const uint8_t* data, size_t length)
+{
+    static const uint8_t hyphen_pos[] = {8, 13, 18, 23};
+    size_t i;
+    unsigned hyphen_i = 0;
+
+    if (data == NULL || length != 36)
+    {
+        return false;
+    }
+
+    for (i = 0; i < 36; i++)
+    {
+        if (hyphen_i < 4 && i == hyphen_pos[hyphen_i])
+        {
+            if (data[i] != '-')
+            {
+                return false;
+            }
+            hyphen_i++;
+            continue;
+        }
+        if (!isxdigit(data[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void uuid_to_upper(char* dst, const uint8_t* src)
+{
+    size_t i;
+    for (i = 0; i < 36; i++)
+    {
+        dst[i] = (char)toupper((unsigned char)src[i]);
+    }
+    dst[36] = '\0';
+}
+
+static bool read_zsm_pascal_string(const uint8_t* data, size_t length, size_t* offset, const uint8_t** out, size_t* out_len)
+{
+    uint8_t str_len;
+
+    if (data == NULL || offset == NULL || *offset >= length)
+    {
+        return false;
+    }
+    str_len = data[*offset];
+    (*offset)++;
+    if (*offset + str_len > length)
+    {
+        return false;
+    }
+    *out = data + *offset;
+    *out_len = str_len;
+    *offset += str_len;
+    return true;
+}
+
+static bool extract_algo_id_from_zsm(const bytes_t zsm, char* algo_id)
+{
+    size_t offset;
+    const uint8_t* str1 = NULL;
+    const uint8_t* str2 = NULL;
+    size_t str1_len = 0;
+    size_t str2_len = 0;
+    size_t end;
+
+    if (zsm.data == NULL || algo_id == NULL || zsm.length < 5)
+    {
+        return false;
+    }
+
+    offset = 3;
+    if (read_zsm_pascal_string(zsm.data, zsm.length, &offset, &str1, &str1_len)
+        && read_zsm_pascal_string(zsm.data, zsm.length, &offset, &str2, &str2_len))
+    {
+        if (is_uuid_text(str2, str2_len))
+        {
+            uuid_to_upper(algo_id, str2);
+            return true;
+        }
+        if (is_uuid_text(str1, str1_len))
+        {
+            uuid_to_upper(algo_id, str1);
+            return true;
+        }
+    }
+
+    end = zsm.length;
+    while (end > 0)
+    {
+        const unsigned char c = zsm.data[end - 1];
+        if (c == '\n' || c == '\r' || c == '\0' || c == ' ' || c == '\t')
+        {
+            end--;
+            continue;
+        }
+        break;
+    }
+    if (end >= 36 && is_uuid_text(zsm.data + (end - 36), 36))
+    {
+        uuid_to_upper(algo_id, zsm.data + (end - 36));
+        return true;
+    }
+    return false;
+}
+
 static bool load_cipher(const bytes_t zsm)
 {
-    LOG_DEBUG("load 函数入口检查, 使用配置: %" PRIu8 ", 下标: %" PRIu8, g_prog_status[tl_thread_idx].login_cfg.idx, tl_thread_idx);
+    char algo_id[ALGO_ID_LEN];
 
+    LOG_DEBUG("load 函数入口检查, 使用配置: %" PRIu8 ", 下标: %" PRIu8, g_prog_status[tl_thread_idx].login_cfg.idx, tl_thread_idx);
     LOG_DEBUG("接收到的 zsm 数据长度: %zu", zsm.length);
     if (zsm.data == NULL || zsm.length == 0) // 检查 zsm 数据是否为空, 为空则返回 false
     {
@@ -272,28 +383,11 @@ static bool load_cipher(const bytes_t zsm)
         return false;
     }
 
-    /**
-     * 提取 zsm 数据到 str 栈中
-     */
-    char str[zsm.length + 1];
-    memcpy(str, zsm.data, zsm.length);
-    str[zsm.length] = '\0';
-
-    const size_t length = strlen(str); // 获取 str 长度
-    LOG_DEBUG("原始字符串: %s", str);
-    LOG_DEBUG("字符串长度: %zu", length);
-    if (length < 4 + 38) // 判断长度, 不足指定长度返回 false
+    if (extract_algo_id_from_zsm(zsm, algo_id) == false)
     {
-        LOG_ERROR("字符串长度不足");
+        LOG_ERROR("无法从 ZSM 中提取 Algo-ID (长度 %zu)", zsm.length);
         return false;
     }
-
-    /**
-     * 提取 algo_id
-     */
-    char algo_id[ALGO_ID_LEN];
-    memcpy(algo_id, str + length - 37, ALGO_ID_LEN - 1);
-    algo_id[ALGO_ID_LEN - 1] = '\0';
     LOG_INFO("Algo ID: %s", algo_id);
 
     /**
@@ -302,7 +396,7 @@ static bool load_cipher(const bytes_t zsm)
      */
     if (init_cipher(algo_id) == false)
     {
-        LOG_ERROR("初始化加解密工厂失败");
+        LOG_ERROR("未知 Algo-ID: %s, 当前通道没有对应密钥", algo_id);
         return false;
     }
     snprintf(g_prog_status[tl_thread_idx].auth_cfg.algo_id, ALGO_ID_LEN, "%s", safe_str(algo_id)); // 将 algo_id 填入认证配置中
@@ -331,26 +425,30 @@ static bool init_session()
         free(result.body_data);
         return false;
     }
-    LOG_VERBOSE("会话响应内容: %s", result.body_data);
-    const bytes_t zsm = str2bytes(result.body_data); // 将响应体数据转成 bytes 类型
-    free(result.body_data);
-
-    LOG_DEBUG("开始初始化会话");
-
-    /**
-     * 加载加解密工厂
-     * 如果失败, 返回 false
-     */
-    if (load_cipher(zsm) == false)
+    LOG_DEBUG("会话响应长度: %zu", result.body_size);
     {
-        LOG_DEBUG("初始化会话失败");
-        g_prog_status[tl_thread_idx].runtime_status.is_initialized = 0;
-        free(zsm.data);
-        return false;
+        const bytes_t zsm = {
+            .data = (uint8_t*)result.body_data,
+            .length = result.body_size
+        };
+
+        LOG_DEBUG("开始初始化会话");
+
+        /**
+         * 加载加解密工厂
+         * 如果失败, 返回 false
+         */
+        if (load_cipher(zsm) == false)
+        {
+            LOG_DEBUG("初始化会话失败");
+            g_prog_status[tl_thread_idx].runtime_status.is_initialized = 0;
+            free(result.body_data);
+            return false;
+        }
     }
     LOG_DEBUG("初始化会话成功");
     g_prog_status[tl_thread_idx].runtime_status.is_initialized = 1;
-    free(zsm.data);
+    free(result.body_data);
     return true;
 }
 

--- a/esurfingclient/main/src/DialerClient.c
+++ b/esurfingclient/main/src/DialerClient.c
@@ -379,7 +379,7 @@ static bool load_cipher(const bytes_t zsm)
     const bool ios_module = looks_like_ios_zsm(zsm.data, zsm.length);
 
     LOG_DEBUG("load 函数入口检查, 使用配置: %" PRIu8 ", 下标: %" PRIu8, g_prog_status[tl_thread_idx].login_cfg.idx, tl_thread_idx);
-    LOG_INFO("当前通道: %" PRIu8 ", ZSM 长度: %zu, iOS 动态模块: %s",
+    LOG_INFO("当前通道: %" PRIu8 ", ZSM 长度: %zu, 动态 ZSM 模块: %s",
              chn, zsm.length, ios_module ? "是" : "否");
     if (zsm.data == NULL || zsm.length == 0) // 检查 zsm 数据是否为空, 为空则返回 false
     {
@@ -388,25 +388,24 @@ static bool load_cipher(const bytes_t zsm)
     }
 
     /**
-     * iOS PacketTunnel 的 ZSM 是 TEA+LZMA 后的 JS 模块, 头部 UUID 只是模块 ID,
-     * 不在 Android/Linux CipherFactory 里. 按内容识别, 避免 LuCI 仍是 phone/pc
-     * 时把 iOS ZSM 误送去查硬编码密钥表, 报 "未知 Algo-ID".
+     * iOS PacketTunnel / macOS GDCV 的 ZSM 都是 TEA+LZMA 后的 JS 模块,
+     * 头部 UUID 只是模块 ID, 不在 Android/Linux CipherFactory 里.
      * 通道号只决定 UA/主机名, 不决定密钥解包方式.
      */
-    if (chn == 4 || ios_module)
+    if (chn == 4 || chn == 5 || ios_module)
     {
-        if (chn != 4)
+        if (chn != 4 && chn != 5)
         {
-            LOG_WARN("通道不是 iOS, 但 ticket 返回了 iOS 动态 ZSM, 按动态密钥解包, UA 不变");
+            LOG_WARN("通道不是 iOS/macOS, 但 ticket 返回了动态 ZSM, 按动态密钥解包, UA 不变");
         }
         if (init_ios_cipher_from_zsm(zsm.data, zsm.length, algo_id) == false)
         {
-            LOG_ERROR("无法按 iOS ZSM 解包出密钥 (长度 %zu, 通道 %" PRIu8 ")", zsm.length, chn);
-            if (chn == 4)
+            LOG_ERROR("无法按动态 ZSM 解包出密钥 (长度 %zu, 通道 %" PRIu8 ")", zsm.length, chn);
+            if (chn == 4 || chn == 5)
             {
                 return false;
             }
-            LOG_WARN("iOS ZSM 解包失败, 回退到 CipherFactory");
+            LOG_WARN("动态 ZSM 解包失败, 回退到 CipherFactory");
         }
         else
         {
@@ -425,7 +424,7 @@ static bool load_cipher(const bytes_t zsm)
 
     if (init_cipher(algo_id) == false)
     {
-        LOG_WARN("CipherFactory 没有 Algo-ID %s, 尝试按 iOS 动态模块解包", algo_id);
+        LOG_WARN("CipherFactory 没有 Algo-ID %s, 尝试按动态 ZSM 解包", algo_id);
         if (init_ios_cipher_from_zsm(zsm.data, zsm.length, algo_id))
         {
             snprintf(g_prog_status[tl_thread_idx].auth_cfg.algo_id, ALGO_ID_LEN, "%s", safe_str(algo_id));
@@ -453,14 +452,14 @@ static bool init_session()
 
     /**
      * 向 ticket_url POST 获取 ZSM.
-     * iOS PacketTunnel 在没有本地模块时 encodeData 返回空 body, 只带
-     * Algo-ID: 00000000-... . Android/Linux 仍 POST 全 0 UUID.
+     * iOS/macOS 没有本地模块时 Algo-ID 为零 UUID, 首次用空 POST.
+     * Android/Linux 仍 POST 全 0 UUID.
      */
     const char* ticket_body = g_prog_status[tl_thread_idx].auth_cfg.algo_id;
-    if (g_prog_status[tl_thread_idx].login_cfg.chn == 4)
+    if (g_prog_status[tl_thread_idx].login_cfg.chn == 4 || g_prog_status[tl_thread_idx].login_cfg.chn == 5)
     {
         ticket_body = "";
-        LOG_INFO("iOS 通道首次拉取 ZSM 使用空 POST");
+        LOG_INFO("iOS/macOS 通道首次拉取 ZSM 使用空 POST");
     }
     const http_resp_t result = post(g_prog_status[tl_thread_idx].auth_cfg.ticket_url, ticket_body);
     if (result.status != REQUEST_HAVE_RES || result.body_size == 0 || result.body_data == NULL) // 响应错误或无响应数据, 则返回 false

--- a/esurfingclient/main/src/States.c
+++ b/esurfingclient/main/src/States.c
@@ -30,6 +30,17 @@ bool g_need_restart = false;
 
 static void reset_host_name()
 {
+    auth_cfg_t* auth_cfg = &g_prog_status[tl_thread_idx].auth_cfg;
+
+    if (g_prog_status[tl_thread_idx].login_cfg.chn == 4)
+    {
+        snprintf(auth_cfg->host_name, HOST_NAME_LEN, "iPhone 14");
+        snprintf(auth_cfg->ostag, OSTAG_LEN, "iPhone iOS 17.0");
+        LOG_DEBUG("iOS 主机名: %s", auth_cfg->host_name);
+        LOG_DEBUG("iOS ostag: %s", auth_cfg->ostag);
+        return;
+    }
+
     char host_name[16];
     unsigned char host_bytes[10];
     get_rand_bytes(host_bytes, 10);
@@ -39,7 +50,8 @@ static void reset_host_name()
     host_bytes[2], host_bytes[3],
     host_bytes[4]);
     LOG_DEBUG("新的主机名: %s", host_name);
-    snprintf(g_prog_status[tl_thread_idx].auth_cfg.host_name, HOST_NAME_LEN, "%s", safe_str(host_name));
+    snprintf(auth_cfg->host_name, HOST_NAME_LEN, "%s", safe_str(host_name));
+    snprintf(auth_cfg->ostag, OSTAG_LEN, "%s", auth_cfg->host_name);
 }
 
 static void reset_client_id()

--- a/esurfingclient/main/src/States.c
+++ b/esurfingclient/main/src/States.c
@@ -40,6 +40,14 @@ static void reset_host_name()
         LOG_DEBUG("iOS ostag: %s", auth_cfg->ostag);
         return;
     }
+    if (g_prog_status[tl_thread_idx].login_cfg.chn == 5)
+    {
+        snprintf(auth_cfg->host_name, HOST_NAME_LEN, "MacBookPro");
+        snprintf(auth_cfg->ostag, OSTAG_LEN, "macOS,14.4");
+        LOG_DEBUG("macOS 主机名: %s", auth_cfg->host_name);
+        LOG_DEBUG("macOS ostag: %s", auth_cfg->ostag);
+        return;
+    }
 
     char host_name[16];
     unsigned char host_bytes[10];

--- a/esurfingclient/main/src/cipher/algo/ios/ios_zsm.c
+++ b/esurfingclient/main/src/cipher/algo/ios/ios_zsm.c
@@ -28,6 +28,7 @@
  *   JS source at buf+0x103
  *
  * JS globals: cdckey, cdciv, cdy(type, mode, key, iv, data)
+ * type 常写在 var codex = 0xNN; 再 cdy(codex, ...)
  * type < 16 → oCode (1-9), type >= 16 → nCode (not ported yet)
  */
 
@@ -128,36 +129,201 @@ static bool zsm_copy_uuid(char* dst, const uint8_t* src, size_t len)
     return true;
 }
 
+static bool is_js_ident_start(unsigned char c)
+{
+    return isalpha(c) || c == '_' || c == '$';
+}
+
+static bool is_js_ident_cont(unsigned char c)
+{
+    return isalnum(c) || c == '_' || c == '$';
+}
+
+static void skip_js_ws_and_comments(const char** pp)
+{
+    const char* p = *pp;
+    while (*p)
+    {
+        if (isspace((unsigned char)*p))
+        {
+            p++;
+            continue;
+        }
+        if (p[0] == '/' && p[1] == '/')
+        {
+            p += 2;
+            while (*p && *p != '\n')
+            {
+                p++;
+            }
+            continue;
+        }
+        if (p[0] == '/' && p[1] == '*')
+        {
+            p += 2;
+            while (*p && !(p[0] == '*' && p[1] == '/'))
+            {
+                p++;
+            }
+            if (*p)
+            {
+                p += 2;
+            }
+            continue;
+        }
+        break;
+    }
+    *pp = p;
+}
+
+static bool parse_js_int(const char* s, const char** end, int* out)
+{
+    unsigned long v;
+    char* parsed = NULL;
+
+    if (s == NULL || *s == '\0')
+    {
+        return false;
+    }
+    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+    {
+        v = strtoul(s, &parsed, 16);
+    }
+    else if (isdigit((unsigned char)*s))
+    {
+        v = strtoul(s, &parsed, 10);
+    }
+    else
+    {
+        return false;
+    }
+    if (parsed == s || v > 32)
+    {
+        return false;
+    }
+    *out = (int)v;
+    if (end)
+    {
+        *end = parsed;
+    }
+    return true;
+}
+
+static int lookup_js_int_var(const char* js, const char* name, size_t name_len)
+{
+    const char* p = js;
+    int last = -1;
+
+    if (js == NULL || name == NULL || name_len == 0)
+    {
+        return -1;
+    }
+    while ((p = strstr(p, name)) != NULL)
+    {
+        const char* q;
+        int n;
+        const char* end;
+
+        if (p > js && is_js_ident_cont((unsigned char)p[-1]))
+        {
+            p += name_len;
+            continue;
+        }
+        if (is_js_ident_cont((unsigned char)p[name_len]))
+        {
+            p += name_len;
+            continue;
+        }
+        q = p + name_len;
+        skip_js_ws_and_comments(&q);
+        if (*q != '=')
+        {
+            p += name_len;
+            continue;
+        }
+        q++;
+        skip_js_ws_and_comments(&q);
+        if (parse_js_int(q, &end, &n) == false)
+        {
+            p += name_len;
+            continue;
+        }
+        last = n;
+        p = end;
+    }
+    return last;
+}
+
 static int parse_cdy_type(const char* js)
 {
     const char* p = js;
     int first = -1;
+    int from_codex;
 
     if (p == NULL)
     {
         return -1;
     }
+
+    /*
+     * PacketTunnel 下发的模块几乎都是:
+     *   var codex = 0x05;
+     *   function e(v) { return cdy(codex, 0, cdckey, cdciv, v); }
+     * 第一参数是变量, 不是字面量. 同时兼容 cdy(5, ...) / cdy(0x05, ...).
+     */
+    from_codex = lookup_js_int_var(js, "codex", 5);
+    if (from_codex >= 1)
+    {
+        LOG_INFO("iOS ZSM JS codex = %d (0x%02X)", from_codex, from_codex);
+    }
+
     while ((p = strstr(p, "cdy")) != NULL)
     {
         const char* q = p + 3;
-        int n = 0;
-        p += 3;
-        while (*q && isspace((unsigned char)*q)) q++;
+        int n = -1;
+        const char* end;
+
+        if (p > js && is_js_ident_cont((unsigned char)p[-1]))
+        {
+            p += 3;
+            continue;
+        }
+        if (is_js_ident_cont((unsigned char)*q))
+        {
+            p += 3;
+            continue;
+        }
+        skip_js_ws_and_comments(&q);
         if (*q != '(')
         {
+            p += 3;
             continue;
         }
         q++;
-        while (*q && isspace((unsigned char)*q)) q++;
-        if (!isdigit((unsigned char)*q))
+        skip_js_ws_and_comments(&q);
+        if (parse_js_int(q, &end, &n))
         {
-            continue;
+            q = end;
         }
-        while (isdigit((unsigned char)*q))
+        else if (is_js_ident_start((unsigned char)*q))
         {
-            n = n * 10 + (*q - '0');
-            q++;
+            const char* id = q;
+            size_t id_len;
+            while (is_js_ident_cont((unsigned char)*q))
+            {
+                q++;
+            }
+            id_len = (size_t)(q - id);
+            if (id_len == 5 && memcmp(id, "codex", 5) == 0 && from_codex >= 0)
+            {
+                n = from_codex;
+            }
+            else
+            {
+                n = lookup_js_int_var(js, id, id_len);
+            }
         }
+        p += 3;
         if (n < 1 || n > 32)
         {
             continue;
@@ -170,6 +336,10 @@ static int parse_cdy_type(const char* js)
         {
             LOG_WARN("ZSM JS 中存在多个 cdy 类型: %d 和 %d, 使用 %d", first, n, first);
         }
+    }
+    if (first < 0 && from_codex >= 1 && from_codex <= 32)
+    {
+        return from_codex;
     }
     return first;
 }
@@ -463,7 +633,7 @@ bool init_ios_cipher_from_zsm(const uint8_t* data, size_t length, char* algo_id_
     type = parse_cdy_type(blob.js);
     if (type < 0)
     {
-        LOG_ERROR("iOS ZSM JS 中没有找到 cdy(type, ...), 无法选择算法");
+        LOG_ERROR("iOS ZSM JS 中没有找到 cdy 类型 (literal 或 var codex = 0xNN), 无法选择算法");
         LOG_ERROR("JS: %.400s", blob.js);
         zsm_blob_free(&blob);
         return false;

--- a/esurfingclient/main/src/cipher/algo/ios/ios_zsm.c
+++ b/esurfingclient/main/src/cipher/algo/ios/ios_zsm.c
@@ -1,0 +1,430 @@
+#include "cipher/IosZsm.h"
+#include "cipher/CipherInterface.h"
+#include "cipher/CipherUtils.h"
+#include "utils/Logger.h"
+#include "States.h"
+
+#include "LzmaDec.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * iOS PacketTunnel IZsmModLoad (sub_10007131C) layout:
+ *
+ *   [3-byte hdr][u8 len1][str1][u8 len2][str2=AID]
+ *   [5-byte LZMA props][u32le packed: top nibble type==2, low 28 bits unpacked size]
+ *   [TEA ciphertext...]
+ *
+ * TEA key (32 ASCII bytes, two 16-byte halves, 32 decrypt rounds each, 8-byte blocks):
+ *   "Rirn53a;feb#UXES5ZrRBTGmYwml:fRt"
+ *
+ * After LZMA:
+ *   buf[0xFA] = IV length
+ *   buf[0xFC] = key length
+ *   buf[0xFF] = key offset base (key at buf[buf[0xFF]+1])
+ *   JS source at buf+0x103
+ *
+ * JS globals: cdckey, cdciv, cdy(type, mode, key, iv, data)
+ * type < 16 → oCode (1-9), type >= 16 → nCode (not ported yet)
+ */
+
+#define ZSM_TEA_KEY "Rirn53a;feb#UXES5ZrRBTGmYwml:fRt"
+#define ZSM_TEA_DELTA 0x61C88647u
+#define ZSM_JS_OFFSET 0x103
+#define ZSM_MAX_UNPACKED 0x8000000u
+
+typedef struct
+{
+    char algo_id[ALGO_ID_LEN];
+    uint8_t* key;
+    size_t key_len;
+    uint8_t* iv;
+    size_t iv_len;
+    char* js;
+} ios_zsm_blob_t;
+
+static void* lzma_alloc(ISzAllocPtr p, size_t size)
+{
+    (void)p;
+    return size ? malloc(size) : NULL;
+}
+
+static void lzma_free(ISzAllocPtr p, void* address)
+{
+    (void)p;
+    free(address);
+}
+
+static const ISzAlloc g_lzma_alloc = { lzma_alloc, lzma_free };
+
+static void zsm_blob_free(ios_zsm_blob_t* blob)
+{
+    if (!blob) return;
+    s_free(blob->key);
+    s_free(blob->iv);
+    s_free(blob->js);
+    memset(blob, 0, sizeof(*blob));
+}
+
+static void zsm_tean_decrypt_block(const uint8_t key16[16], uint8_t block[8])
+{
+    uint32_t k[4];
+    uint32_t v0;
+    uint32_t v1;
+    uint32_t sum;
+    int i;
+
+    for (i = 0; i < 4; i++)
+    {
+        k[i] = bytes_2_uint32_le(key16 + (size_t)i * 4);
+    }
+    v0 = bytes_2_uint32_le(block);
+    v1 = bytes_2_uint32_le(block + 4);
+    sum = ZSM_TEA_DELTA * (uint32_t)(-32); /* 0xC6EF3720 */
+    do
+    {
+        v1 -= ((v0 << 4) ^ (v0 >> 5)) + (k[(sum >> 11) & 3] + (v0 ^ sum));
+        sum += ZSM_TEA_DELTA;
+        v0 -= (k[sum & 3] + (v1 ^ sum)) + ((v1 << 4) ^ (v1 >> 5));
+    } while (sum != 0);
+    uint32_2_bytes_le(v0, block);
+    uint32_2_bytes_le(v1, block + 4);
+}
+
+static void zsm_tea_decrypt_buffer(uint8_t* data, size_t length)
+{
+    static const uint8_t key[] = ZSM_TEA_KEY;
+    size_t off;
+
+    for (off = 0; off < length; off += 8)
+    {
+        zsm_tean_decrypt_block(key, data + off);
+        zsm_tean_decrypt_block(key + 16, data + off);
+    }
+}
+
+static bool zsm_copy_uuid(char* dst, const uint8_t* src, size_t len)
+{
+    size_t i;
+    if (dst == NULL || src == NULL || len != 36)
+    {
+        return false;
+    }
+    for (i = 0; i < 36; i++)
+    {
+        const unsigned char c = src[i];
+        const int is_hex = isxdigit(c);
+        const int is_dash = (i == 8 || i == 13 || i == 18 || i == 23) && c == '-';
+        if (!is_hex && !is_dash)
+        {
+            return false;
+        }
+        dst[i] = (char)toupper(c);
+    }
+    dst[36] = '\0';
+    return true;
+}
+
+static int parse_cdy_type(const char* js)
+{
+    const char* p = js;
+    int first = -1;
+
+    if (p == NULL)
+    {
+        return -1;
+    }
+    while ((p = strstr(p, "cdy")) != NULL)
+    {
+        const char* q = p + 3;
+        int n = 0;
+        p += 3;
+        while (*q && isspace((unsigned char)*q)) q++;
+        if (*q != '(')
+        {
+            continue;
+        }
+        q++;
+        while (*q && isspace((unsigned char)*q)) q++;
+        if (!isdigit((unsigned char)*q))
+        {
+            continue;
+        }
+        while (isdigit((unsigned char)*q))
+        {
+            n = n * 10 + (*q - '0');
+            q++;
+        }
+        if (n < 1 || n > 32)
+        {
+            continue;
+        }
+        if (first < 0)
+        {
+            first = n;
+        }
+        else if (first != n)
+        {
+            LOG_WARN("ZSM JS 中存在多个 cdy 类型: %d 和 %d, 使用 %d", first, n, first);
+        }
+    }
+    return first;
+}
+
+static void copy_padded(uint8_t* dst, size_t dst_len, const uint8_t* src, size_t src_len, const char* what)
+{
+    memset(dst, 0, dst_len);
+    if (src == NULL || src_len == 0)
+    {
+        LOG_WARN("iOS ZSM %s 为空, 按 %zu 字节零填充", what, dst_len);
+        return;
+    }
+    if (src_len != dst_len)
+    {
+        LOG_WARN("iOS ZSM %s 长度 %zu, 算法需要 %zu, 将截断或补零", what, src_len, dst_len);
+    }
+    memcpy(dst, src, src_len < dst_len ? src_len : dst_len);
+}
+
+static cipher_interface_t* create_ios_ocode_cipher(int type, const uint8_t* key, size_t key_len,
+                                                   const uint8_t* iv, size_t iv_len)
+{
+    uint8_t key_buf[48];
+    uint8_t iv_buf[16];
+    uint8_t rotated[48];
+
+    switch (type)
+    {
+    case 1: /* 双层 AES-128-ECB */
+        copy_padded(key_buf, 32, key, key_len, "key");
+        return create_aes_double_ecb_android_cipher(key_buf);
+    case 2: /* 双层 AES-128-CBC */
+        copy_padded(key_buf, 32, key, key_len, "key");
+        copy_padded(iv_buf, 16, iv, iv_len, "iv");
+        return create_aes_double_cbc_android_cipher(key_buf, iv_buf);
+    case 3: /* 六轮 DES-ECB: iOS 顺序是 K4,K5,K6,K1,K2,K3, 旋转后复用 Android 实现 */
+        copy_padded(key_buf, 48, key, key_len, "key");
+        memcpy(rotated, key_buf + 24, 24);
+        memcpy(rotated + 24, key_buf, 24);
+        return create_des_ecb_six_android_cipher(rotated);
+    case 4: /* 双层 3DES-CBC, 第一轮 key[24:48], 第二轮 key[0:24] */
+        copy_padded(key_buf, 48, key, key_len, "key");
+        copy_padded(iv_buf, 8, iv, iv_len, "iv");
+        return create_desede_double_cbc_android_cipher(key_buf, iv_buf);
+    case 5: /* 三层改 TEA-ECB */
+        copy_padded(key_buf, 48, key, key_len, "key");
+        return create_tea_triple_ecb_android_cipher(key_buf);
+    case 6: /* 三层改 TEA-CBC */
+        copy_padded(key_buf, 48, key, key_len, "key");
+        copy_padded(iv_buf, 8, iv, iv_len, "iv");
+        return create_tea_triple_cbc_android_cipher(key_buf, iv_buf);
+    case 7: /* SM4-ECB */
+        copy_padded(key_buf, 16, key, key_len, "key");
+        return create_sm4_variant_ecb_android_cipher(key_buf);
+    case 8: /* SM4-CBC */
+        copy_padded(key_buf, 16, key, key_len, "key");
+        copy_padded(iv_buf, 16, iv, iv_len, "iv");
+        return create_sm4_variant_cbc_android_cipher(key_buf, iv_buf);
+    case 9: /* SNOW3G 变体 */
+        copy_padded(key_buf, 16, key, key_len, "key");
+        copy_padded(iv_buf, 16, iv, iv_len, "iv");
+        return create_snow3g_variant_android_cipher(key_buf, iv_buf);
+    default:
+        return NULL;
+    }
+}
+
+static bool unwrap_ios_zsm(const uint8_t* data, size_t length, ios_zsm_blob_t* out)
+{
+    size_t offset;
+    uint8_t len1;
+    uint8_t len2;
+    const uint8_t* str2;
+    const uint8_t* props;
+    uint32_t packed;
+    uint32_t unpacked_size;
+    uint32_t type_nibble;
+    size_t remain;
+    size_t cipher_len;
+    uint8_t* cipher = NULL;
+    uint8_t pad;
+    SizeT src_len;
+    SizeT dest_len;
+    uint8_t* unpacked = NULL;
+    ELzmaStatus status;
+    SRes lzma_ret;
+    uint8_t key_off;
+    uint8_t key_len;
+    uint8_t iv_len;
+    const uint8_t* key_ptr;
+    const uint8_t* iv_ptr;
+    const char* js;
+
+    memset(out, 0, sizeof(*out));
+    if (data == NULL || length < 15)
+    {
+        LOG_ERROR("iOS ZSM 太短: %zu", length);
+        return false;
+    }
+
+    offset = 3;
+    len1 = data[offset++];
+    if (offset + len1 + 1 > length)
+    {
+        LOG_ERROR("iOS ZSM str1 越界");
+        return false;
+    }
+    offset += len1;
+    len2 = data[offset++];
+    if (offset + len2 > length)
+    {
+        LOG_ERROR("iOS ZSM str2 越界");
+        return false;
+    }
+    str2 = data + offset;
+    if (zsm_copy_uuid(out->algo_id, str2, len2))
+    {
+        LOG_INFO("iOS ZSM Algo-ID: %s", out->algo_id);
+    }
+    else
+    {
+        LOG_WARN("iOS ZSM str2 不是 UUID (len=%u), 仍继续解包", len2);
+        snprintf(out->algo_id, ALGO_ID_LEN, "00000000-0000-0000-0000-000000000000");
+    }
+    offset += len2;
+    remain = length - offset;
+    if (remain <= 9)
+    {
+        LOG_ERROR("iOS ZSM 剩余长度不足: %zu", remain);
+        return false;
+    }
+
+    props = data + offset;
+    packed = bytes_2_uint32_le(props + 5);
+    type_nibble = packed >> 28;
+    unpacked_size = packed & 0x0FFFFFFFu;
+    if (type_nibble != 2 || unpacked_size == 0 || unpacked_size > ZSM_MAX_UNPACKED)
+    {
+        LOG_ERROR("iOS ZSM packed 头非法: type=%u size=%u", type_nibble, unpacked_size);
+        return false;
+    }
+
+    cipher_len = remain - 9;
+    cipher = s_calloc(1, cipher_len + 8);
+    memcpy(cipher, props + 9, cipher_len);
+    zsm_tea_decrypt_buffer(cipher, cipher_len);
+
+    pad = cipher_len ? cipher[cipher_len - 1] : 0;
+    if (pad > cipher_len)
+    {
+        LOG_ERROR("iOS ZSM TEA 填充长度非法: %u / %zu", pad, cipher_len);
+        s_free(cipher);
+        return false;
+    }
+    src_len = (SizeT)(cipher_len - pad);
+    dest_len = (SizeT)unpacked_size;
+    unpacked = s_calloc(1, (size_t)unpacked_size + 1);
+    lzma_ret = LzmaDecode(unpacked, &dest_len, cipher, &src_len, props, 5,
+                          LZMA_FINISH_ANY, &status, &g_lzma_alloc);
+    s_free(cipher);
+    cipher = NULL;
+    if (lzma_ret != SZ_OK)
+    {
+        LOG_ERROR("iOS ZSM LZMA 解压失败: %d", lzma_ret);
+        s_free(unpacked);
+        return false;
+    }
+
+    key_off = unpacked[0xFF];
+    key_len = unpacked[0xFC];
+    iv_len = unpacked[0xFA];
+    if ((unsigned)key_off + (unsigned)key_len + (unsigned)iv_len >= 0xFA || dest_len <= ZSM_JS_OFFSET)
+    {
+        LOG_ERROR("iOS ZSM 明文头非法: key_off=%u key_len=%u iv_len=%u unpacked=%u",
+                  key_off, key_len, iv_len, (unsigned)dest_len);
+        s_free(unpacked);
+        return false;
+    }
+
+    key_ptr = unpacked + key_off + 1;
+    iv_ptr = key_ptr + key_len;
+    js = (const char*)(unpacked + ZSM_JS_OFFSET);
+
+    out->key_len = key_len;
+    out->key = s_malloc(key_len + 1);
+    memcpy(out->key, key_ptr, key_len);
+    out->key[key_len] = 0;
+
+    if (iv_len == 0 || (iv_len == 4 && memcmp(iv_ptr, "noiv", 4) == 0))
+    {
+        out->iv = NULL;
+        out->iv_len = 0;
+    }
+    else
+    {
+        out->iv_len = iv_len;
+        out->iv = s_malloc(iv_len + 1);
+        memcpy(out->iv, iv_ptr, iv_len);
+        out->iv[iv_len] = 0;
+    }
+
+    out->js = s_malloc(strlen(js) + 1);
+    memcpy(out->js, js, strlen(js) + 1);
+    s_free(unpacked);
+
+    LOG_INFO("iOS ZSM 解包成功: key_len=%zu iv_len=%zu js_len=%zu",
+             out->key_len, out->iv_len, strlen(out->js));
+    LOG_DEBUG("iOS ZSM JS 开头: %.240s", out->js);
+    if (strstr(out->js, "pxs") || strstr(out->js, "txs"))
+    {
+        LOG_WARN("iOS ZSM JS 调用了 pxs/txs, 当前只执行 cdy 加解密, 若认证失败需要把 JS 贴出来");
+    }
+    return true;
+}
+
+bool init_ios_cipher_from_zsm(const uint8_t* data, size_t length, char* algo_id_out)
+{
+    ios_zsm_blob_t blob;
+    int type;
+    cipher_interface_t* cipher;
+
+    if (!unwrap_ios_zsm(data, length, &blob))
+    {
+        return false;
+    }
+    if (algo_id_out)
+    {
+        snprintf(algo_id_out, ALGO_ID_LEN, "%s", blob.algo_id);
+    }
+
+    type = parse_cdy_type(blob.js);
+    if (type < 0)
+    {
+        LOG_ERROR("iOS ZSM JS 中没有找到 cdy(type, ...), 无法选择算法");
+        LOG_ERROR("JS: %.400s", blob.js);
+        zsm_blob_free(&blob);
+        return false;
+    }
+    LOG_INFO("iOS ZSM cdy 类型: %d", type);
+    if (type >= 16)
+    {
+        LOG_ERROR("iOS ZSM 使用 nCode 类型 %d, 目前只移植了 oCode 1-9", type);
+        zsm_blob_free(&blob);
+        return false;
+    }
+
+    cipher = create_ios_ocode_cipher(type, blob.key, blob.key_len, blob.iv, blob.iv_len);
+    zsm_blob_free(&blob);
+    if (cipher == NULL)
+    {
+        LOG_ERROR("iOS ZSM 无法创建类型 %d 的加解密工厂", type);
+        return false;
+    }
+
+    g_prog_status[tl_thread_idx].auth_cfg.cipher = cipher;
+    LOG_DEBUG("iOS ZSM 加解密工厂已就绪");
+    return true;
+}

--- a/esurfingclient/main/src/cipher/algo/ios/ios_zsm.c
+++ b/esurfingclient/main/src/cipher/algo/ios/ios_zsm.c
@@ -237,6 +237,59 @@ static cipher_interface_t* create_ios_ocode_cipher(int type, const uint8_t* key,
     }
 }
 
+
+static void log_zsm_prefix(const uint8_t* data, size_t length)
+{
+    char hex[97];
+    size_t n = length < 32 ? length : 32;
+    size_t i;
+    for (i = 0; i < n; i++)
+    {
+        sprintf(hex + i * 3, "%02X ", data[i]);
+    }
+    if (n)
+    {
+        hex[n * 3 - 1] = '\0';
+    }
+    else
+    {
+        hex[0] = '\0';
+    }
+    LOG_INFO("ZSM 前 %zu 字节: %s", n, hex);
+}
+
+bool looks_like_ios_zsm(const uint8_t* data, size_t length)
+{
+    size_t offset;
+    uint8_t len1;
+    uint8_t len2;
+    uint32_t packed;
+    uint32_t type_nibble;
+    uint32_t unpacked_size;
+
+    if (data == NULL || length < 15)
+    {
+        return false;
+    }
+    offset = 3;
+    len1 = data[offset++];
+    if (offset + len1 + 1 > length)
+    {
+        return false;
+    }
+    offset += len1;
+    len2 = data[offset++];
+    if (offset + len2 + 9 > length)
+    {
+        return false;
+    }
+    offset += len2;
+    packed = bytes_2_uint32_le(data + offset + 5);
+    type_nibble = packed >> 28;
+    unpacked_size = packed & 0x0FFFFFFFu;
+    return type_nibble == 2 && unpacked_size >= 1 && unpacked_size <= ZSM_MAX_UNPACKED;
+}
+
 static bool unwrap_ios_zsm(const uint8_t* data, size_t length, ios_zsm_blob_t* out)
 {
     size_t offset;
@@ -267,8 +320,13 @@ static bool unwrap_ios_zsm(const uint8_t* data, size_t length, ios_zsm_blob_t* o
     if (data == NULL || length < 15)
     {
         LOG_ERROR("iOS ZSM 太短: %zu", length);
+        if (data && length)
+        {
+            log_zsm_prefix(data, length);
+        }
         return false;
     }
+    log_zsm_prefix(data, length);
 
     offset = 3;
     len1 = data[offset++];
@@ -308,7 +366,9 @@ static bool unwrap_ios_zsm(const uint8_t* data, size_t length, ios_zsm_blob_t* o
     unpacked_size = packed & 0x0FFFFFFFu;
     if (type_nibble != 2 || unpacked_size == 0 || unpacked_size > ZSM_MAX_UNPACKED)
     {
-        LOG_ERROR("iOS ZSM packed 头非法: type=%u size=%u", type_nibble, unpacked_size);
+        LOG_ERROR("iOS ZSM packed 头非法: type=%u size=%u remain=%zu props=%02X %02X %02X %02X %02X",
+                  type_nibble, unpacked_size, remain,
+                  props[0], props[1], props[2], props[3], props[4]);
         return false;
     }
 

--- a/esurfingclient/main/src/cipher/algo/ios/lzma/7zTypes.h
+++ b/esurfingclient/main/src/cipher/algo/ios/lzma/7zTypes.h
@@ -1,0 +1,374 @@
+/* 7zTypes.h -- Basic types
+2017-07-17 : Igor Pavlov : Public domain */
+
+#ifndef __7Z_TYPES_H
+#define __7Z_TYPES_H
+
+#ifdef _WIN32
+/* #include <windows.h> */
+#endif
+
+#include <stddef.h>
+
+#ifndef EXTERN_C_BEGIN
+#ifdef __cplusplus
+#define EXTERN_C_BEGIN extern "C" {
+#define EXTERN_C_END }
+#else
+#define EXTERN_C_BEGIN
+#define EXTERN_C_END
+#endif
+#endif
+
+EXTERN_C_BEGIN
+
+#define SZ_OK 0
+
+#define SZ_ERROR_DATA 1
+#define SZ_ERROR_MEM 2
+#define SZ_ERROR_CRC 3
+#define SZ_ERROR_UNSUPPORTED 4
+#define SZ_ERROR_PARAM 5
+#define SZ_ERROR_INPUT_EOF 6
+#define SZ_ERROR_OUTPUT_EOF 7
+#define SZ_ERROR_READ 8
+#define SZ_ERROR_WRITE 9
+#define SZ_ERROR_PROGRESS 10
+#define SZ_ERROR_FAIL 11
+#define SZ_ERROR_THREAD 12
+
+#define SZ_ERROR_ARCHIVE 16
+#define SZ_ERROR_NO_ARCHIVE 17
+
+typedef int SRes;
+
+
+#ifdef _WIN32
+
+/* typedef DWORD WRes; */
+typedef unsigned WRes;
+#define MY_SRes_HRESULT_FROM_WRes(x) HRESULT_FROM_WIN32(x)
+
+#else
+
+typedef int WRes;
+#define MY__FACILITY_WIN32 7
+#define MY__FACILITY__WRes MY__FACILITY_WIN32
+#define MY_SRes_HRESULT_FROM_WRes(x) ((HRESULT)(x) <= 0 ? ((HRESULT)(x)) : ((HRESULT) (((x) & 0x0000FFFF) | (MY__FACILITY__WRes << 16) | 0x80000000)))
+
+#endif
+
+
+#ifndef RINOK
+#define RINOK(x) { int __result__ = (x); if (__result__ != 0) return __result__; }
+#endif
+
+typedef unsigned char Byte;
+typedef short Int16;
+typedef unsigned short UInt16;
+
+#ifdef _LZMA_UINT32_IS_ULONG
+typedef long Int32;
+typedef unsigned long UInt32;
+#else
+typedef int Int32;
+typedef unsigned int UInt32;
+#endif
+
+#ifdef _SZ_NO_INT_64
+
+/* define _SZ_NO_INT_64, if your compiler doesn't support 64-bit integers.
+   NOTES: Some code will work incorrectly in that case! */
+
+typedef long Int64;
+typedef unsigned long UInt64;
+
+#else
+
+#if defined(_MSC_VER) || defined(__BORLANDC__)
+typedef __int64 Int64;
+typedef unsigned __int64 UInt64;
+#define UINT64_CONST(n) n
+#else
+typedef long long int Int64;
+typedef unsigned long long int UInt64;
+#define UINT64_CONST(n) n ## ULL
+#endif
+
+#endif
+
+#ifdef _LZMA_NO_SYSTEM_SIZE_T
+typedef UInt32 SizeT;
+#else
+typedef size_t SizeT;
+#endif
+
+typedef int Bool;
+#define True 1
+#define False 0
+
+
+#ifdef _WIN32
+#define MY_STD_CALL __stdcall
+#else
+#define MY_STD_CALL
+#endif
+
+#ifdef _MSC_VER
+
+#if _MSC_VER >= 1300
+#define MY_NO_INLINE __declspec(noinline)
+#else
+#define MY_NO_INLINE
+#endif
+
+#define MY_FORCE_INLINE __forceinline
+
+#define MY_CDECL __cdecl
+#define MY_FAST_CALL __fastcall
+
+#else
+
+#define MY_NO_INLINE
+#define MY_FORCE_INLINE
+#define MY_CDECL
+#define MY_FAST_CALL
+
+/* inline keyword : for C++ / C99 */
+
+/* GCC, clang: */
+/*
+#if defined (__GNUC__) && (__GNUC__ >= 4)
+#define MY_FORCE_INLINE __attribute__((always_inline))
+#define MY_NO_INLINE __attribute__((noinline))
+#endif
+*/
+
+#endif
+
+
+/* The following interfaces use first parameter as pointer to structure */
+
+typedef struct IByteIn IByteIn;
+struct IByteIn
+{
+  Byte (*Read)(const IByteIn *p); /* reads one byte, returns 0 in case of EOF or error */
+};
+#define IByteIn_Read(p) (p)->Read(p)
+
+
+typedef struct IByteOut IByteOut;
+struct IByteOut
+{
+  void (*Write)(const IByteOut *p, Byte b);
+};
+#define IByteOut_Write(p, b) (p)->Write(p, b)
+
+
+typedef struct ISeqInStream ISeqInStream;
+struct ISeqInStream
+{
+  SRes (*Read)(const ISeqInStream *p, void *buf, size_t *size);
+    /* if (input(*size) != 0 && output(*size) == 0) means end_of_stream.
+       (output(*size) < input(*size)) is allowed */
+};
+#define ISeqInStream_Read(p, buf, size) (p)->Read(p, buf, size)
+
+/* it can return SZ_ERROR_INPUT_EOF */
+SRes SeqInStream_Read(const ISeqInStream *stream, void *buf, size_t size);
+SRes SeqInStream_Read2(const ISeqInStream *stream, void *buf, size_t size, SRes errorType);
+SRes SeqInStream_ReadByte(const ISeqInStream *stream, Byte *buf);
+
+
+typedef struct ISeqOutStream ISeqOutStream;
+struct ISeqOutStream
+{
+  size_t (*Write)(const ISeqOutStream *p, const void *buf, size_t size);
+    /* Returns: result - the number of actually written bytes.
+       (result < size) means error */
+};
+#define ISeqOutStream_Write(p, buf, size) (p)->Write(p, buf, size)
+
+typedef enum
+{
+  SZ_SEEK_SET = 0,
+  SZ_SEEK_CUR = 1,
+  SZ_SEEK_END = 2
+} ESzSeek;
+
+
+typedef struct ISeekInStream ISeekInStream;
+struct ISeekInStream
+{
+  SRes (*Read)(const ISeekInStream *p, void *buf, size_t *size);  /* same as ISeqInStream::Read */
+  SRes (*Seek)(const ISeekInStream *p, Int64 *pos, ESzSeek origin);
+};
+#define ISeekInStream_Read(p, buf, size)   (p)->Read(p, buf, size)
+#define ISeekInStream_Seek(p, pos, origin) (p)->Seek(p, pos, origin)
+
+
+typedef struct ILookInStream ILookInStream;
+struct ILookInStream
+{
+  SRes (*Look)(const ILookInStream *p, const void **buf, size_t *size);
+    /* if (input(*size) != 0 && output(*size) == 0) means end_of_stream.
+       (output(*size) > input(*size)) is not allowed
+       (output(*size) < input(*size)) is allowed */
+  SRes (*Skip)(const ILookInStream *p, size_t offset);
+    /* offset must be <= output(*size) of Look */
+
+  SRes (*Read)(const ILookInStream *p, void *buf, size_t *size);
+    /* reads directly (without buffer). It's same as ISeqInStream::Read */
+  SRes (*Seek)(const ILookInStream *p, Int64 *pos, ESzSeek origin);
+};
+
+#define ILookInStream_Look(p, buf, size)   (p)->Look(p, buf, size)
+#define ILookInStream_Skip(p, offset)      (p)->Skip(p, offset)
+#define ILookInStream_Read(p, buf, size)   (p)->Read(p, buf, size)
+#define ILookInStream_Seek(p, pos, origin) (p)->Seek(p, pos, origin)
+
+
+SRes LookInStream_LookRead(const ILookInStream *stream, void *buf, size_t *size);
+SRes LookInStream_SeekTo(const ILookInStream *stream, UInt64 offset);
+
+/* reads via ILookInStream::Read */
+SRes LookInStream_Read2(const ILookInStream *stream, void *buf, size_t size, SRes errorType);
+SRes LookInStream_Read(const ILookInStream *stream, void *buf, size_t size);
+
+
+
+typedef struct
+{
+  ILookInStream vt;
+  const ISeekInStream *realStream;
+ 
+  size_t pos;
+  size_t size; /* it's data size */
+  
+  /* the following variables must be set outside */
+  Byte *buf;
+  size_t bufSize;
+} CLookToRead2;
+
+void LookToRead2_CreateVTable(CLookToRead2 *p, int lookahead);
+
+#define LookToRead2_Init(p) { (p)->pos = (p)->size = 0; }
+
+
+typedef struct
+{
+  ISeqInStream vt;
+  const ILookInStream *realStream;
+} CSecToLook;
+
+void SecToLook_CreateVTable(CSecToLook *p);
+
+
+
+typedef struct
+{
+  ISeqInStream vt;
+  const ILookInStream *realStream;
+} CSecToRead;
+
+void SecToRead_CreateVTable(CSecToRead *p);
+
+
+typedef struct ICompressProgress ICompressProgress;
+
+struct ICompressProgress
+{
+  SRes (*Progress)(const ICompressProgress *p, UInt64 inSize, UInt64 outSize);
+    /* Returns: result. (result != SZ_OK) means break.
+       Value (UInt64)(Int64)-1 for size means unknown value. */
+};
+#define ICompressProgress_Progress(p, inSize, outSize) (p)->Progress(p, inSize, outSize)
+
+
+
+typedef struct ISzAlloc ISzAlloc;
+typedef const ISzAlloc * ISzAllocPtr;
+
+struct ISzAlloc
+{
+  void *(*Alloc)(ISzAllocPtr p, size_t size);
+  void (*Free)(ISzAllocPtr p, void *address); /* address can be 0 */
+};
+
+#define ISzAlloc_Alloc(p, size) (p)->Alloc(p, size)
+#define ISzAlloc_Free(p, a) (p)->Free(p, a)
+
+/* deprecated */
+#define IAlloc_Alloc(p, size) ISzAlloc_Alloc(p, size)
+#define IAlloc_Free(p, a) ISzAlloc_Free(p, a)
+
+
+
+
+
+#ifndef MY_offsetof
+  #ifdef offsetof
+    #define MY_offsetof(type, m) offsetof(type, m)
+    /*
+    #define MY_offsetof(type, m) FIELD_OFFSET(type, m)
+    */
+  #else
+    #define MY_offsetof(type, m) ((size_t)&(((type *)0)->m))
+  #endif
+#endif
+
+
+
+#ifndef MY_container_of
+
+/*
+#define MY_container_of(ptr, type, m) container_of(ptr, type, m)
+#define MY_container_of(ptr, type, m) CONTAINING_RECORD(ptr, type, m)
+#define MY_container_of(ptr, type, m) ((type *)((char *)(ptr) - offsetof(type, m)))
+#define MY_container_of(ptr, type, m) (&((type *)0)->m == (ptr), ((type *)(((char *)(ptr)) - MY_offsetof(type, m))))
+*/
+
+/*
+  GCC shows warning: "perhaps the 'offsetof' macro was used incorrectly"
+    GCC 3.4.4 : classes with constructor
+    GCC 4.8.1 : classes with non-public variable members"
+*/
+
+#define MY_container_of(ptr, type, m) ((type *)((char *)(1 ? (ptr) : &((type *)0)->m) - MY_offsetof(type, m)))
+
+
+#endif
+
+#define CONTAINER_FROM_VTBL_SIMPLE(ptr, type, m) ((type *)(ptr))
+
+/*
+#define CONTAINER_FROM_VTBL(ptr, type, m) CONTAINER_FROM_VTBL_SIMPLE(ptr, type, m)
+*/
+#define CONTAINER_FROM_VTBL(ptr, type, m) MY_container_of(ptr, type, m)
+
+#define CONTAINER_FROM_VTBL_CLS(ptr, type, m) CONTAINER_FROM_VTBL_SIMPLE(ptr, type, m)
+/*
+#define CONTAINER_FROM_VTBL_CLS(ptr, type, m) CONTAINER_FROM_VTBL(ptr, type, m)
+*/
+
+
+
+#ifdef _WIN32
+
+#define CHAR_PATH_SEPARATOR '\\'
+#define WCHAR_PATH_SEPARATOR L'\\'
+#define STRING_PATH_SEPARATOR "\\"
+#define WSTRING_PATH_SEPARATOR L"\\"
+
+#else
+
+#define CHAR_PATH_SEPARATOR '/'
+#define WCHAR_PATH_SEPARATOR L'/'
+#define STRING_PATH_SEPARATOR "/"
+#define WSTRING_PATH_SEPARATOR L"/"
+
+#endif
+
+EXTERN_C_END
+
+#endif

--- a/esurfingclient/main/src/cipher/algo/ios/lzma/LzmaDec.c
+++ b/esurfingclient/main/src/cipher/algo/ios/lzma/LzmaDec.c
@@ -1,0 +1,1185 @@
+/* LzmaDec.c -- LZMA Decoder
+2018-02-28 : Igor Pavlov : Public domain */
+
+#include "Precomp.h"
+
+/* #include "CpuArch.h" */
+#include "LzmaDec.h"
+
+#include <string.h>
+
+#define kNumTopBits 24
+#define kTopValue ((UInt32)1 << kNumTopBits)
+
+#define kNumBitModelTotalBits 11
+#define kBitModelTotal (1 << kNumBitModelTotalBits)
+#define kNumMoveBits 5
+
+#define RC_INIT_SIZE 5
+
+#define NORMALIZE if (range < kTopValue) { range <<= 8; code = (code << 8) | (*buf++); }
+
+#define IF_BIT_0(p) ttt = *(p); NORMALIZE; bound = (range >> kNumBitModelTotalBits) * ttt; if (code < bound)
+#define UPDATE_0(p) range = bound; *(p) = (CLzmaProb)(ttt + ((kBitModelTotal - ttt) >> kNumMoveBits));
+#define UPDATE_1(p) range -= bound; code -= bound; *(p) = (CLzmaProb)(ttt - (ttt >> kNumMoveBits));
+#define GET_BIT2(p, i, A0, A1) IF_BIT_0(p) \
+  { UPDATE_0(p); i = (i + i); A0; } else \
+  { UPDATE_1(p); i = (i + i) + 1; A1; }
+
+#define TREE_GET_BIT(probs, i) { GET_BIT2(probs + i, i, ;, ;); }
+
+#define REV_BIT(p, i, A0, A1) IF_BIT_0(p + i) \
+  { UPDATE_0(p + i); A0; } else \
+  { UPDATE_1(p + i); A1; }
+#define REV_BIT_VAR(  p, i, m) REV_BIT(p, i, i += m; m += m, m += m; i += m; )
+#define REV_BIT_CONST(p, i, m) REV_BIT(p, i, i += m;       , i += m * 2; )
+#define REV_BIT_LAST( p, i, m) REV_BIT(p, i, i -= m        , ; )
+
+#define TREE_DECODE(probs, limit, i) \
+  { i = 1; do { TREE_GET_BIT(probs, i); } while (i < limit); i -= limit; }
+
+/* #define _LZMA_SIZE_OPT */
+
+#ifdef _LZMA_SIZE_OPT
+#define TREE_6_DECODE(probs, i) TREE_DECODE(probs, (1 << 6), i)
+#else
+#define TREE_6_DECODE(probs, i) \
+  { i = 1; \
+  TREE_GET_BIT(probs, i); \
+  TREE_GET_BIT(probs, i); \
+  TREE_GET_BIT(probs, i); \
+  TREE_GET_BIT(probs, i); \
+  TREE_GET_BIT(probs, i); \
+  TREE_GET_BIT(probs, i); \
+  i -= 0x40; }
+#endif
+
+#define NORMAL_LITER_DEC TREE_GET_BIT(prob, symbol)
+#define MATCHED_LITER_DEC \
+  matchByte += matchByte; \
+  bit = offs; \
+  offs &= matchByte; \
+  probLit = prob + (offs + bit + symbol); \
+  GET_BIT2(probLit, symbol, offs ^= bit; , ;)
+
+
+
+#define NORMALIZE_CHECK if (range < kTopValue) { if (buf >= bufLimit) return DUMMY_ERROR; range <<= 8; code = (code << 8) | (*buf++); }
+
+#define IF_BIT_0_CHECK(p) ttt = *(p); NORMALIZE_CHECK; bound = (range >> kNumBitModelTotalBits) * ttt; if (code < bound)
+#define UPDATE_0_CHECK range = bound;
+#define UPDATE_1_CHECK range -= bound; code -= bound;
+#define GET_BIT2_CHECK(p, i, A0, A1) IF_BIT_0_CHECK(p) \
+  { UPDATE_0_CHECK; i = (i + i); A0; } else \
+  { UPDATE_1_CHECK; i = (i + i) + 1; A1; }
+#define GET_BIT_CHECK(p, i) GET_BIT2_CHECK(p, i, ; , ;)
+#define TREE_DECODE_CHECK(probs, limit, i) \
+  { i = 1; do { GET_BIT_CHECK(probs + i, i) } while (i < limit); i -= limit; }
+
+
+#define REV_BIT_CHECK(p, i, m) IF_BIT_0_CHECK(p + i) \
+  { UPDATE_0_CHECK; i += m; m += m; } else \
+  { UPDATE_1_CHECK; m += m; i += m; }
+
+
+#define kNumPosBitsMax 4
+#define kNumPosStatesMax (1 << kNumPosBitsMax)
+
+#define kLenNumLowBits 3
+#define kLenNumLowSymbols (1 << kLenNumLowBits)
+#define kLenNumHighBits 8
+#define kLenNumHighSymbols (1 << kLenNumHighBits)
+
+#define LenLow 0
+#define LenHigh (LenLow + 2 * (kNumPosStatesMax << kLenNumLowBits))
+#define kNumLenProbs (LenHigh + kLenNumHighSymbols)
+
+#define LenChoice LenLow
+#define LenChoice2 (LenLow + (1 << kLenNumLowBits))
+
+#define kNumStates 12
+#define kNumStates2 16
+#define kNumLitStates 7
+
+#define kStartPosModelIndex 4
+#define kEndPosModelIndex 14
+#define kNumFullDistances (1 << (kEndPosModelIndex >> 1))
+
+#define kNumPosSlotBits 6
+#define kNumLenToPosStates 4
+
+#define kNumAlignBits 4
+#define kAlignTableSize (1 << kNumAlignBits)
+
+#define kMatchMinLen 2
+#define kMatchSpecLenStart (kMatchMinLen + kLenNumLowSymbols * 2 + kLenNumHighSymbols)
+
+/* External ASM code needs same CLzmaProb array layout. So don't change it. */
+
+/* (probs_1664) is faster and better for code size at some platforms */
+/*
+#ifdef MY_CPU_X86_OR_AMD64
+*/
+#define kStartOffset 1664
+#define GET_PROBS p->probs_1664
+/*
+#define GET_PROBS p->probs + kStartOffset
+#else
+#define kStartOffset 0
+#define GET_PROBS p->probs
+#endif
+*/
+
+#define SpecPos (-kStartOffset)
+#define IsRep0Long (SpecPos + kNumFullDistances)
+#define RepLenCoder (IsRep0Long + (kNumStates2 << kNumPosBitsMax))
+#define LenCoder (RepLenCoder + kNumLenProbs)
+#define IsMatch (LenCoder + kNumLenProbs)
+#define Align (IsMatch + (kNumStates2 << kNumPosBitsMax))
+#define IsRep (Align + kAlignTableSize)
+#define IsRepG0 (IsRep + kNumStates)
+#define IsRepG1 (IsRepG0 + kNumStates)
+#define IsRepG2 (IsRepG1 + kNumStates)
+#define PosSlot (IsRepG2 + kNumStates)
+#define Literal (PosSlot + (kNumLenToPosStates << kNumPosSlotBits))
+#define NUM_BASE_PROBS (Literal + kStartOffset)
+
+#if Align != 0 && kStartOffset != 0
+  #error Stop_Compiling_Bad_LZMA_kAlign
+#endif
+
+#if NUM_BASE_PROBS != 1984
+  #error Stop_Compiling_Bad_LZMA_PROBS
+#endif
+
+
+#define LZMA_LIT_SIZE 0x300
+
+#define LzmaProps_GetNumProbs(p) (NUM_BASE_PROBS + ((UInt32)LZMA_LIT_SIZE << ((p)->lc + (p)->lp)))
+
+
+#define CALC_POS_STATE(processedPos, pbMask) (((processedPos) & (pbMask)) << 4)
+#define COMBINED_PS_STATE (posState + state)
+#define GET_LEN_STATE (posState)
+
+#define LZMA_DIC_MIN (1 << 12)
+
+/*
+p->remainLen : shows status of LZMA decoder:
+    < kMatchSpecLenStart : normal remain
+    = kMatchSpecLenStart : finished
+    = kMatchSpecLenStart + 1 : need init range coder
+    = kMatchSpecLenStart + 2 : need init range coder and state
+*/
+
+/* ---------- LZMA_DECODE_REAL ---------- */
+/*
+LzmaDec_DecodeReal_3() can be implemented in external ASM file.
+3 - is the code compatibility version of that function for check at link time.
+*/
+
+#define LZMA_DECODE_REAL LzmaDec_DecodeReal_3
+
+/*
+LZMA_DECODE_REAL()
+In:
+  RangeCoder is normalized
+  if (p->dicPos == limit)
+  {
+    LzmaDec_TryDummy() was called before to exclude LITERAL and MATCH-REP cases.
+    So first symbol can be only MATCH-NON-REP. And if that MATCH-NON-REP symbol
+    is not END_OF_PAYALOAD_MARKER, then function returns error code.
+  }
+
+Processing:
+  first LZMA symbol will be decoded in any case
+  All checks for limits are at the end of main loop,
+  It will decode new LZMA-symbols while (p->buf < bufLimit && dicPos < limit),
+  RangeCoder is still without last normalization when (p->buf < bufLimit) is being checked.
+
+Out:
+  RangeCoder is normalized
+  Result:
+    SZ_OK - OK
+    SZ_ERROR_DATA - Error
+  p->remainLen:
+    < kMatchSpecLenStart : normal remain
+    = kMatchSpecLenStart : finished
+*/
+
+
+#ifdef _LZMA_DEC_OPT
+
+int MY_FAST_CALL LZMA_DECODE_REAL(CLzmaDec *p, SizeT limit, const Byte *bufLimit);
+
+#else
+
+static
+int MY_FAST_CALL LZMA_DECODE_REAL(CLzmaDec *p, SizeT limit, const Byte *bufLimit)
+{
+  CLzmaProb *probs = GET_PROBS;
+  unsigned state = (unsigned)p->state;
+  UInt32 rep0 = p->reps[0], rep1 = p->reps[1], rep2 = p->reps[2], rep3 = p->reps[3];
+  unsigned pbMask = ((unsigned)1 << (p->prop.pb)) - 1;
+  unsigned lc = p->prop.lc;
+  unsigned lpMask = ((unsigned)0x100 << p->prop.lp) - ((unsigned)0x100 >> lc);
+
+  Byte *dic = p->dic;
+  SizeT dicBufSize = p->dicBufSize;
+  SizeT dicPos = p->dicPos;
+  
+  UInt32 processedPos = p->processedPos;
+  UInt32 checkDicSize = p->checkDicSize;
+  unsigned len = 0;
+
+  const Byte *buf = p->buf;
+  UInt32 range = p->range;
+  UInt32 code = p->code;
+
+  do
+  {
+    CLzmaProb *prob;
+    UInt32 bound;
+    unsigned ttt;
+    unsigned posState = CALC_POS_STATE(processedPos, pbMask);
+
+    prob = probs + IsMatch + COMBINED_PS_STATE;
+    IF_BIT_0(prob)
+    {
+      unsigned symbol;
+      UPDATE_0(prob);
+      prob = probs + Literal;
+      if (processedPos != 0 || checkDicSize != 0)
+        prob += (UInt32)3 * ((((processedPos << 8) + dic[(dicPos == 0 ? dicBufSize : dicPos) - 1]) & lpMask) << lc);
+      processedPos++;
+
+      if (state < kNumLitStates)
+      {
+        state -= (state < 4) ? state : 3;
+        symbol = 1;
+        #ifdef _LZMA_SIZE_OPT
+        do { NORMAL_LITER_DEC } while (symbol < 0x100);
+        #else
+        NORMAL_LITER_DEC
+        NORMAL_LITER_DEC
+        NORMAL_LITER_DEC
+        NORMAL_LITER_DEC
+        NORMAL_LITER_DEC
+        NORMAL_LITER_DEC
+        NORMAL_LITER_DEC
+        NORMAL_LITER_DEC
+        #endif
+      }
+      else
+      {
+        unsigned matchByte = dic[dicPos - rep0 + (dicPos < rep0 ? dicBufSize : 0)];
+        unsigned offs = 0x100;
+        state -= (state < 10) ? 3 : 6;
+        symbol = 1;
+        #ifdef _LZMA_SIZE_OPT
+        do
+        {
+          unsigned bit;
+          CLzmaProb *probLit;
+          MATCHED_LITER_DEC
+        }
+        while (symbol < 0x100);
+        #else
+        {
+          unsigned bit;
+          CLzmaProb *probLit;
+          MATCHED_LITER_DEC
+          MATCHED_LITER_DEC
+          MATCHED_LITER_DEC
+          MATCHED_LITER_DEC
+          MATCHED_LITER_DEC
+          MATCHED_LITER_DEC
+          MATCHED_LITER_DEC
+          MATCHED_LITER_DEC
+        }
+        #endif
+      }
+
+      dic[dicPos++] = (Byte)symbol;
+      continue;
+    }
+    
+    {
+      UPDATE_1(prob);
+      prob = probs + IsRep + state;
+      IF_BIT_0(prob)
+      {
+        UPDATE_0(prob);
+        state += kNumStates;
+        prob = probs + LenCoder;
+      }
+      else
+      {
+        UPDATE_1(prob);
+        /*
+        // that case was checked before with kBadRepCode
+        if (checkDicSize == 0 && processedPos == 0)
+          return SZ_ERROR_DATA;
+        */
+        prob = probs + IsRepG0 + state;
+        IF_BIT_0(prob)
+        {
+          UPDATE_0(prob);
+          prob = probs + IsRep0Long + COMBINED_PS_STATE;
+          IF_BIT_0(prob)
+          {
+            UPDATE_0(prob);
+            dic[dicPos] = dic[dicPos - rep0 + (dicPos < rep0 ? dicBufSize : 0)];
+            dicPos++;
+            processedPos++;
+            state = state < kNumLitStates ? 9 : 11;
+            continue;
+          }
+          UPDATE_1(prob);
+        }
+        else
+        {
+          UInt32 distance;
+          UPDATE_1(prob);
+          prob = probs + IsRepG1 + state;
+          IF_BIT_0(prob)
+          {
+            UPDATE_0(prob);
+            distance = rep1;
+          }
+          else
+          {
+            UPDATE_1(prob);
+            prob = probs + IsRepG2 + state;
+            IF_BIT_0(prob)
+            {
+              UPDATE_0(prob);
+              distance = rep2;
+            }
+            else
+            {
+              UPDATE_1(prob);
+              distance = rep3;
+              rep3 = rep2;
+            }
+            rep2 = rep1;
+          }
+          rep1 = rep0;
+          rep0 = distance;
+        }
+        state = state < kNumLitStates ? 8 : 11;
+        prob = probs + RepLenCoder;
+      }
+      
+      #ifdef _LZMA_SIZE_OPT
+      {
+        unsigned lim, offset;
+        CLzmaProb *probLen = prob + LenChoice;
+        IF_BIT_0(probLen)
+        {
+          UPDATE_0(probLen);
+          probLen = prob + LenLow + GET_LEN_STATE;
+          offset = 0;
+          lim = (1 << kLenNumLowBits);
+        }
+        else
+        {
+          UPDATE_1(probLen);
+          probLen = prob + LenChoice2;
+          IF_BIT_0(probLen)
+          {
+            UPDATE_0(probLen);
+            probLen = prob + LenLow + GET_LEN_STATE + (1 << kLenNumLowBits);
+            offset = kLenNumLowSymbols;
+            lim = (1 << kLenNumLowBits);
+          }
+          else
+          {
+            UPDATE_1(probLen);
+            probLen = prob + LenHigh;
+            offset = kLenNumLowSymbols * 2;
+            lim = (1 << kLenNumHighBits);
+          }
+        }
+        TREE_DECODE(probLen, lim, len);
+        len += offset;
+      }
+      #else
+      {
+        CLzmaProb *probLen = prob + LenChoice;
+        IF_BIT_0(probLen)
+        {
+          UPDATE_0(probLen);
+          probLen = prob + LenLow + GET_LEN_STATE;
+          len = 1;
+          TREE_GET_BIT(probLen, len);
+          TREE_GET_BIT(probLen, len);
+          TREE_GET_BIT(probLen, len);
+          len -= 8;
+        }
+        else
+        {
+          UPDATE_1(probLen);
+          probLen = prob + LenChoice2;
+          IF_BIT_0(probLen)
+          {
+            UPDATE_0(probLen);
+            probLen = prob + LenLow + GET_LEN_STATE + (1 << kLenNumLowBits);
+            len = 1;
+            TREE_GET_BIT(probLen, len);
+            TREE_GET_BIT(probLen, len);
+            TREE_GET_BIT(probLen, len);
+          }
+          else
+          {
+            UPDATE_1(probLen);
+            probLen = prob + LenHigh;
+            TREE_DECODE(probLen, (1 << kLenNumHighBits), len);
+            len += kLenNumLowSymbols * 2;
+          }
+        }
+      }
+      #endif
+
+      if (state >= kNumStates)
+      {
+        UInt32 distance;
+        prob = probs + PosSlot +
+            ((len < kNumLenToPosStates ? len : kNumLenToPosStates - 1) << kNumPosSlotBits);
+        TREE_6_DECODE(prob, distance);
+        if (distance >= kStartPosModelIndex)
+        {
+          unsigned posSlot = (unsigned)distance;
+          unsigned numDirectBits = (unsigned)(((distance >> 1) - 1));
+          distance = (2 | (distance & 1));
+          if (posSlot < kEndPosModelIndex)
+          {
+            distance <<= numDirectBits;
+            prob = probs + SpecPos;
+            {
+              UInt32 m = 1;
+              distance++;
+              do
+              {
+                REV_BIT_VAR(prob, distance, m);
+              }
+              while (--numDirectBits);
+              distance -= m;
+            }
+          }
+          else
+          {
+            numDirectBits -= kNumAlignBits;
+            do
+            {
+              NORMALIZE
+              range >>= 1;
+              
+              {
+                UInt32 t;
+                code -= range;
+                t = (0 - ((UInt32)code >> 31)); /* (UInt32)((Int32)code >> 31) */
+                distance = (distance << 1) + (t + 1);
+                code += range & t;
+              }
+              /*
+              distance <<= 1;
+              if (code >= range)
+              {
+                code -= range;
+                distance |= 1;
+              }
+              */
+            }
+            while (--numDirectBits);
+            prob = probs + Align;
+            distance <<= kNumAlignBits;
+            {
+              unsigned i = 1;
+              REV_BIT_CONST(prob, i, 1);
+              REV_BIT_CONST(prob, i, 2);
+              REV_BIT_CONST(prob, i, 4);
+              REV_BIT_LAST (prob, i, 8);
+              distance |= i;
+            }
+            if (distance == (UInt32)0xFFFFFFFF)
+            {
+              len = kMatchSpecLenStart;
+              state -= kNumStates;
+              break;
+            }
+          }
+        }
+        
+        rep3 = rep2;
+        rep2 = rep1;
+        rep1 = rep0;
+        rep0 = distance + 1;
+        state = (state < kNumStates + kNumLitStates) ? kNumLitStates : kNumLitStates + 3;
+        if (distance >= (checkDicSize == 0 ? processedPos: checkDicSize))
+        {
+          p->dicPos = dicPos;
+          return SZ_ERROR_DATA;
+        }
+      }
+
+      len += kMatchMinLen;
+
+      {
+        SizeT rem;
+        unsigned curLen;
+        SizeT pos;
+        
+        if ((rem = limit - dicPos) == 0)
+        {
+          p->dicPos = dicPos;
+          return SZ_ERROR_DATA;
+        }
+        
+        curLen = ((rem < len) ? (unsigned)rem : len);
+        pos = dicPos - rep0 + (dicPos < rep0 ? dicBufSize : 0);
+
+        processedPos += curLen;
+
+        len -= curLen;
+        if (curLen <= dicBufSize - pos)
+        {
+          Byte *dest = dic + dicPos;
+          ptrdiff_t src = (ptrdiff_t)pos - (ptrdiff_t)dicPos;
+          const Byte *lim = dest + curLen;
+          dicPos += curLen;
+          do
+            *(dest) = (Byte)*(dest + src);
+          while (++dest != lim);
+        }
+        else
+        {
+          do
+          {
+            dic[dicPos++] = dic[pos];
+            if (++pos == dicBufSize)
+              pos = 0;
+          }
+          while (--curLen != 0);
+        }
+      }
+    }
+  }
+  while (dicPos < limit && buf < bufLimit);
+
+  NORMALIZE;
+  
+  p->buf = buf;
+  p->range = range;
+  p->code = code;
+  p->remainLen = len;
+  p->dicPos = dicPos;
+  p->processedPos = processedPos;
+  p->reps[0] = rep0;
+  p->reps[1] = rep1;
+  p->reps[2] = rep2;
+  p->reps[3] = rep3;
+  p->state = state;
+
+  return SZ_OK;
+}
+#endif
+
+static void MY_FAST_CALL LzmaDec_WriteRem(CLzmaDec *p, SizeT limit)
+{
+  if (p->remainLen != 0 && p->remainLen < kMatchSpecLenStart)
+  {
+    Byte *dic = p->dic;
+    SizeT dicPos = p->dicPos;
+    SizeT dicBufSize = p->dicBufSize;
+    unsigned len = (unsigned)p->remainLen;
+    SizeT rep0 = p->reps[0]; /* we use SizeT to avoid the BUG of VC14 for AMD64 */
+    SizeT rem = limit - dicPos;
+    if (rem < len)
+      len = (unsigned)(rem);
+
+    if (p->checkDicSize == 0 && p->prop.dicSize - p->processedPos <= len)
+      p->checkDicSize = p->prop.dicSize;
+
+    p->processedPos += len;
+    p->remainLen -= len;
+    while (len != 0)
+    {
+      len--;
+      dic[dicPos] = dic[dicPos - rep0 + (dicPos < rep0 ? dicBufSize : 0)];
+      dicPos++;
+    }
+    p->dicPos = dicPos;
+  }
+}
+
+
+#define kRange0 0xFFFFFFFF
+#define kBound0 ((kRange0 >> kNumBitModelTotalBits) << (kNumBitModelTotalBits - 1))
+#define kBadRepCode (kBound0 + (((kRange0 - kBound0) >> kNumBitModelTotalBits) << (kNumBitModelTotalBits - 1)))
+#if kBadRepCode != (0xC0000000 - 0x400)
+  #error Stop_Compiling_Bad_LZMA_Check
+#endif
+
+static int MY_FAST_CALL LzmaDec_DecodeReal2(CLzmaDec *p, SizeT limit, const Byte *bufLimit)
+{
+  do
+  {
+    SizeT limit2 = limit;
+    if (p->checkDicSize == 0)
+    {
+      UInt32 rem = p->prop.dicSize - p->processedPos;
+      if (limit - p->dicPos > rem)
+        limit2 = p->dicPos + rem;
+
+      if (p->processedPos == 0)
+        if (p->code >= kBadRepCode)
+          return SZ_ERROR_DATA;
+    }
+
+    RINOK(LZMA_DECODE_REAL(p, limit2, bufLimit));
+    
+    if (p->checkDicSize == 0 && p->processedPos >= p->prop.dicSize)
+      p->checkDicSize = p->prop.dicSize;
+    
+    LzmaDec_WriteRem(p, limit);
+  }
+  while (p->dicPos < limit && p->buf < bufLimit && p->remainLen < kMatchSpecLenStart);
+
+  return 0;
+}
+
+typedef enum
+{
+  DUMMY_ERROR, /* unexpected end of input stream */
+  DUMMY_LIT,
+  DUMMY_MATCH,
+  DUMMY_REP
+} ELzmaDummy;
+
+static ELzmaDummy LzmaDec_TryDummy(const CLzmaDec *p, const Byte *buf, SizeT inSize)
+{
+  UInt32 range = p->range;
+  UInt32 code = p->code;
+  const Byte *bufLimit = buf + inSize;
+  const CLzmaProb *probs = GET_PROBS;
+  unsigned state = (unsigned)p->state;
+  ELzmaDummy res;
+
+  {
+    const CLzmaProb *prob;
+    UInt32 bound;
+    unsigned ttt;
+    unsigned posState = CALC_POS_STATE(p->processedPos, (1 << p->prop.pb) - 1);
+
+    prob = probs + IsMatch + COMBINED_PS_STATE;
+    IF_BIT_0_CHECK(prob)
+    {
+      UPDATE_0_CHECK
+
+      /* if (bufLimit - buf >= 7) return DUMMY_LIT; */
+
+      prob = probs + Literal;
+      if (p->checkDicSize != 0 || p->processedPos != 0)
+        prob += ((UInt32)LZMA_LIT_SIZE *
+            ((((p->processedPos) & ((1 << (p->prop.lp)) - 1)) << p->prop.lc) +
+            (p->dic[(p->dicPos == 0 ? p->dicBufSize : p->dicPos) - 1] >> (8 - p->prop.lc))));
+
+      if (state < kNumLitStates)
+      {
+        unsigned symbol = 1;
+        do { GET_BIT_CHECK(prob + symbol, symbol) } while (symbol < 0x100);
+      }
+      else
+      {
+        unsigned matchByte = p->dic[p->dicPos - p->reps[0] +
+            (p->dicPos < p->reps[0] ? p->dicBufSize : 0)];
+        unsigned offs = 0x100;
+        unsigned symbol = 1;
+        do
+        {
+          unsigned bit;
+          const CLzmaProb *probLit;
+          matchByte += matchByte;
+          bit = offs;
+          offs &= matchByte;
+          probLit = prob + (offs + bit + symbol);
+          GET_BIT2_CHECK(probLit, symbol, offs ^= bit; , ; )
+        }
+        while (symbol < 0x100);
+      }
+      res = DUMMY_LIT;
+    }
+    else
+    {
+      unsigned len;
+      UPDATE_1_CHECK;
+
+      prob = probs + IsRep + state;
+      IF_BIT_0_CHECK(prob)
+      {
+        UPDATE_0_CHECK;
+        state = 0;
+        prob = probs + LenCoder;
+        res = DUMMY_MATCH;
+      }
+      else
+      {
+        UPDATE_1_CHECK;
+        res = DUMMY_REP;
+        prob = probs + IsRepG0 + state;
+        IF_BIT_0_CHECK(prob)
+        {
+          UPDATE_0_CHECK;
+          prob = probs + IsRep0Long + COMBINED_PS_STATE;
+          IF_BIT_0_CHECK(prob)
+          {
+            UPDATE_0_CHECK;
+            NORMALIZE_CHECK;
+            return DUMMY_REP;
+          }
+          else
+          {
+            UPDATE_1_CHECK;
+          }
+        }
+        else
+        {
+          UPDATE_1_CHECK;
+          prob = probs + IsRepG1 + state;
+          IF_BIT_0_CHECK(prob)
+          {
+            UPDATE_0_CHECK;
+          }
+          else
+          {
+            UPDATE_1_CHECK;
+            prob = probs + IsRepG2 + state;
+            IF_BIT_0_CHECK(prob)
+            {
+              UPDATE_0_CHECK;
+            }
+            else
+            {
+              UPDATE_1_CHECK;
+            }
+          }
+        }
+        state = kNumStates;
+        prob = probs + RepLenCoder;
+      }
+      {
+        unsigned limit, offset;
+        const CLzmaProb *probLen = prob + LenChoice;
+        IF_BIT_0_CHECK(probLen)
+        {
+          UPDATE_0_CHECK;
+          probLen = prob + LenLow + GET_LEN_STATE;
+          offset = 0;
+          limit = 1 << kLenNumLowBits;
+        }
+        else
+        {
+          UPDATE_1_CHECK;
+          probLen = prob + LenChoice2;
+          IF_BIT_0_CHECK(probLen)
+          {
+            UPDATE_0_CHECK;
+            probLen = prob + LenLow + GET_LEN_STATE + (1 << kLenNumLowBits);
+            offset = kLenNumLowSymbols;
+            limit = 1 << kLenNumLowBits;
+          }
+          else
+          {
+            UPDATE_1_CHECK;
+            probLen = prob + LenHigh;
+            offset = kLenNumLowSymbols * 2;
+            limit = 1 << kLenNumHighBits;
+          }
+        }
+        TREE_DECODE_CHECK(probLen, limit, len);
+        len += offset;
+      }
+
+      if (state < 4)
+      {
+        unsigned posSlot;
+        prob = probs + PosSlot +
+            ((len < kNumLenToPosStates - 1 ? len : kNumLenToPosStates - 1) <<
+            kNumPosSlotBits);
+        TREE_DECODE_CHECK(prob, 1 << kNumPosSlotBits, posSlot);
+        if (posSlot >= kStartPosModelIndex)
+        {
+          unsigned numDirectBits = ((posSlot >> 1) - 1);
+
+          /* if (bufLimit - buf >= 8) return DUMMY_MATCH; */
+
+          if (posSlot < kEndPosModelIndex)
+          {
+            prob = probs + SpecPos + ((2 | (posSlot & 1)) << numDirectBits);
+          }
+          else
+          {
+            numDirectBits -= kNumAlignBits;
+            do
+            {
+              NORMALIZE_CHECK
+              range >>= 1;
+              code -= range & (((code - range) >> 31) - 1);
+              /* if (code >= range) code -= range; */
+            }
+            while (--numDirectBits);
+            prob = probs + Align;
+            numDirectBits = kNumAlignBits;
+          }
+          {
+            unsigned i = 1;
+            unsigned m = 1;
+            do
+            {
+              REV_BIT_CHECK(prob, i, m);
+            }
+            while (--numDirectBits);
+          }
+        }
+      }
+    }
+  }
+  NORMALIZE_CHECK;
+  return res;
+}
+
+
+void LzmaDec_InitDicAndState(CLzmaDec *p, Bool initDic, Bool initState)
+{
+  p->remainLen = kMatchSpecLenStart + 1;
+  p->tempBufSize = 0;
+
+  if (initDic)
+  {
+    p->processedPos = 0;
+    p->checkDicSize = 0;
+    p->remainLen = kMatchSpecLenStart + 2;
+  }
+  if (initState)
+    p->remainLen = kMatchSpecLenStart + 2;
+}
+
+void LzmaDec_Init(CLzmaDec *p)
+{
+  p->dicPos = 0;
+  LzmaDec_InitDicAndState(p, True, True);
+}
+
+
+SRes LzmaDec_DecodeToDic(CLzmaDec *p, SizeT dicLimit, const Byte *src, SizeT *srcLen,
+    ELzmaFinishMode finishMode, ELzmaStatus *status)
+{
+  SizeT inSize = *srcLen;
+  (*srcLen) = 0;
+  
+  *status = LZMA_STATUS_NOT_SPECIFIED;
+
+  if (p->remainLen > kMatchSpecLenStart)
+  {
+    for (; inSize > 0 && p->tempBufSize < RC_INIT_SIZE; (*srcLen)++, inSize--)
+      p->tempBuf[p->tempBufSize++] = *src++;
+    if (p->tempBufSize != 0 && p->tempBuf[0] != 0)
+      return SZ_ERROR_DATA;
+    if (p->tempBufSize < RC_INIT_SIZE)
+    {
+      *status = LZMA_STATUS_NEEDS_MORE_INPUT;
+      return SZ_OK;
+    }
+    p->code =
+        ((UInt32)p->tempBuf[1] << 24)
+      | ((UInt32)p->tempBuf[2] << 16)
+      | ((UInt32)p->tempBuf[3] << 8)
+      | ((UInt32)p->tempBuf[4]);
+    p->range = 0xFFFFFFFF;
+    p->tempBufSize = 0;
+
+    if (p->remainLen > kMatchSpecLenStart + 1)
+    {
+      SizeT numProbs = LzmaProps_GetNumProbs(&p->prop);
+      SizeT i;
+      CLzmaProb *probs = p->probs;
+      for (i = 0; i < numProbs; i++)
+        probs[i] = kBitModelTotal >> 1;
+      p->reps[0] = p->reps[1] = p->reps[2] = p->reps[3] = 1;
+      p->state = 0;
+    }
+
+    p->remainLen = 0;
+  }
+
+  LzmaDec_WriteRem(p, dicLimit);
+
+  while (p->remainLen != kMatchSpecLenStart)
+  {
+      int checkEndMarkNow = 0;
+
+      if (p->dicPos >= dicLimit)
+      {
+        if (p->remainLen == 0 && p->code == 0)
+        {
+          *status = LZMA_STATUS_MAYBE_FINISHED_WITHOUT_MARK;
+          return SZ_OK;
+        }
+        if (finishMode == LZMA_FINISH_ANY)
+        {
+          *status = LZMA_STATUS_NOT_FINISHED;
+          return SZ_OK;
+        }
+        if (p->remainLen != 0)
+        {
+          *status = LZMA_STATUS_NOT_FINISHED;
+          return SZ_ERROR_DATA;
+        }
+        checkEndMarkNow = 1;
+      }
+
+      if (p->tempBufSize == 0)
+      {
+        SizeT processed;
+        const Byte *bufLimit;
+        if (inSize < LZMA_REQUIRED_INPUT_MAX || checkEndMarkNow)
+        {
+          int dummyRes = LzmaDec_TryDummy(p, src, inSize);
+          if (dummyRes == DUMMY_ERROR)
+          {
+            memcpy(p->tempBuf, src, inSize);
+            p->tempBufSize = (unsigned)inSize;
+            (*srcLen) += inSize;
+            *status = LZMA_STATUS_NEEDS_MORE_INPUT;
+            return SZ_OK;
+          }
+          if (checkEndMarkNow && dummyRes != DUMMY_MATCH)
+          {
+            *status = LZMA_STATUS_NOT_FINISHED;
+            return SZ_ERROR_DATA;
+          }
+          bufLimit = src;
+        }
+        else
+          bufLimit = src + inSize - LZMA_REQUIRED_INPUT_MAX;
+        p->buf = src;
+        if (LzmaDec_DecodeReal2(p, dicLimit, bufLimit) != 0)
+          return SZ_ERROR_DATA;
+        processed = (SizeT)(p->buf - src);
+        (*srcLen) += processed;
+        src += processed;
+        inSize -= processed;
+      }
+      else
+      {
+        unsigned rem = p->tempBufSize, lookAhead = 0;
+        while (rem < LZMA_REQUIRED_INPUT_MAX && lookAhead < inSize)
+          p->tempBuf[rem++] = src[lookAhead++];
+        p->tempBufSize = rem;
+        if (rem < LZMA_REQUIRED_INPUT_MAX || checkEndMarkNow)
+        {
+          int dummyRes = LzmaDec_TryDummy(p, p->tempBuf, rem);
+          if (dummyRes == DUMMY_ERROR)
+          {
+            (*srcLen) += lookAhead;
+            *status = LZMA_STATUS_NEEDS_MORE_INPUT;
+            return SZ_OK;
+          }
+          if (checkEndMarkNow && dummyRes != DUMMY_MATCH)
+          {
+            *status = LZMA_STATUS_NOT_FINISHED;
+            return SZ_ERROR_DATA;
+          }
+        }
+        p->buf = p->tempBuf;
+        if (LzmaDec_DecodeReal2(p, dicLimit, p->buf) != 0)
+          return SZ_ERROR_DATA;
+        
+        {
+          unsigned kkk = (unsigned)(p->buf - p->tempBuf);
+          if (rem < kkk)
+            return SZ_ERROR_FAIL; /* some internal error */
+          rem -= kkk;
+          if (lookAhead < rem)
+            return SZ_ERROR_FAIL; /* some internal error */
+          lookAhead -= rem;
+        }
+        (*srcLen) += lookAhead;
+        src += lookAhead;
+        inSize -= lookAhead;
+        p->tempBufSize = 0;
+      }
+  }
+  
+  if (p->code != 0)
+    return SZ_ERROR_DATA;
+  *status = LZMA_STATUS_FINISHED_WITH_MARK;
+  return SZ_OK;
+}
+
+
+SRes LzmaDec_DecodeToBuf(CLzmaDec *p, Byte *dest, SizeT *destLen, const Byte *src, SizeT *srcLen, ELzmaFinishMode finishMode, ELzmaStatus *status)
+{
+  SizeT outSize = *destLen;
+  SizeT inSize = *srcLen;
+  *srcLen = *destLen = 0;
+  for (;;)
+  {
+    SizeT inSizeCur = inSize, outSizeCur, dicPos;
+    ELzmaFinishMode curFinishMode;
+    SRes res;
+    if (p->dicPos == p->dicBufSize)
+      p->dicPos = 0;
+    dicPos = p->dicPos;
+    if (outSize > p->dicBufSize - dicPos)
+    {
+      outSizeCur = p->dicBufSize;
+      curFinishMode = LZMA_FINISH_ANY;
+    }
+    else
+    {
+      outSizeCur = dicPos + outSize;
+      curFinishMode = finishMode;
+    }
+
+    res = LzmaDec_DecodeToDic(p, outSizeCur, src, &inSizeCur, curFinishMode, status);
+    src += inSizeCur;
+    inSize -= inSizeCur;
+    *srcLen += inSizeCur;
+    outSizeCur = p->dicPos - dicPos;
+    memcpy(dest, p->dic + dicPos, outSizeCur);
+    dest += outSizeCur;
+    outSize -= outSizeCur;
+    *destLen += outSizeCur;
+    if (res != 0)
+      return res;
+    if (outSizeCur == 0 || outSize == 0)
+      return SZ_OK;
+  }
+}
+
+void LzmaDec_FreeProbs(CLzmaDec *p, ISzAllocPtr alloc)
+{
+  ISzAlloc_Free(alloc, p->probs);
+  p->probs = NULL;
+}
+
+static void LzmaDec_FreeDict(CLzmaDec *p, ISzAllocPtr alloc)
+{
+  ISzAlloc_Free(alloc, p->dic);
+  p->dic = NULL;
+}
+
+void LzmaDec_Free(CLzmaDec *p, ISzAllocPtr alloc)
+{
+  LzmaDec_FreeProbs(p, alloc);
+  LzmaDec_FreeDict(p, alloc);
+}
+
+SRes LzmaProps_Decode(CLzmaProps *p, const Byte *data, unsigned size)
+{
+  UInt32 dicSize;
+  Byte d;
+  
+  if (size < LZMA_PROPS_SIZE)
+    return SZ_ERROR_UNSUPPORTED;
+  else
+    dicSize = data[1] | ((UInt32)data[2] << 8) | ((UInt32)data[3] << 16) | ((UInt32)data[4] << 24);
+ 
+  if (dicSize < LZMA_DIC_MIN)
+    dicSize = LZMA_DIC_MIN;
+  p->dicSize = dicSize;
+
+  d = data[0];
+  if (d >= (9 * 5 * 5))
+    return SZ_ERROR_UNSUPPORTED;
+
+  p->lc = (Byte)(d % 9);
+  d /= 9;
+  p->pb = (Byte)(d / 5);
+  p->lp = (Byte)(d % 5);
+
+  return SZ_OK;
+}
+
+static SRes LzmaDec_AllocateProbs2(CLzmaDec *p, const CLzmaProps *propNew, ISzAllocPtr alloc)
+{
+  UInt32 numProbs = LzmaProps_GetNumProbs(propNew);
+  if (!p->probs || numProbs != p->numProbs)
+  {
+    LzmaDec_FreeProbs(p, alloc);
+    p->probs = (CLzmaProb *)ISzAlloc_Alloc(alloc, numProbs * sizeof(CLzmaProb));
+    if (!p->probs)
+      return SZ_ERROR_MEM;
+    p->probs_1664 = p->probs + 1664;
+    p->numProbs = numProbs;
+  }
+  return SZ_OK;
+}
+
+SRes LzmaDec_AllocateProbs(CLzmaDec *p, const Byte *props, unsigned propsSize, ISzAllocPtr alloc)
+{
+  CLzmaProps propNew;
+  RINOK(LzmaProps_Decode(&propNew, props, propsSize));
+  RINOK(LzmaDec_AllocateProbs2(p, &propNew, alloc));
+  p->prop = propNew;
+  return SZ_OK;
+}
+
+SRes LzmaDec_Allocate(CLzmaDec *p, const Byte *props, unsigned propsSize, ISzAllocPtr alloc)
+{
+  CLzmaProps propNew;
+  SizeT dicBufSize;
+  RINOK(LzmaProps_Decode(&propNew, props, propsSize));
+  RINOK(LzmaDec_AllocateProbs2(p, &propNew, alloc));
+
+  {
+    UInt32 dictSize = propNew.dicSize;
+    SizeT mask = ((UInt32)1 << 12) - 1;
+         if (dictSize >= ((UInt32)1 << 30)) mask = ((UInt32)1 << 22) - 1;
+    else if (dictSize >= ((UInt32)1 << 22)) mask = ((UInt32)1 << 20) - 1;;
+    dicBufSize = ((SizeT)dictSize + mask) & ~mask;
+    if (dicBufSize < dictSize)
+      dicBufSize = dictSize;
+  }
+
+  if (!p->dic || dicBufSize != p->dicBufSize)
+  {
+    LzmaDec_FreeDict(p, alloc);
+    p->dic = (Byte *)ISzAlloc_Alloc(alloc, dicBufSize);
+    if (!p->dic)
+    {
+      LzmaDec_FreeProbs(p, alloc);
+      return SZ_ERROR_MEM;
+    }
+  }
+  p->dicBufSize = dicBufSize;
+  p->prop = propNew;
+  return SZ_OK;
+}
+
+SRes LzmaDecode(Byte *dest, SizeT *destLen, const Byte *src, SizeT *srcLen,
+    const Byte *propData, unsigned propSize, ELzmaFinishMode finishMode,
+    ELzmaStatus *status, ISzAllocPtr alloc)
+{
+  CLzmaDec p;
+  SRes res;
+  SizeT outSize = *destLen, inSize = *srcLen;
+  *destLen = *srcLen = 0;
+  *status = LZMA_STATUS_NOT_SPECIFIED;
+  if (inSize < RC_INIT_SIZE)
+    return SZ_ERROR_INPUT_EOF;
+  LzmaDec_Construct(&p);
+  RINOK(LzmaDec_AllocateProbs(&p, propData, propSize, alloc));
+  p.dic = dest;
+  p.dicBufSize = outSize;
+  LzmaDec_Init(&p);
+  *srcLen = inSize;
+  res = LzmaDec_DecodeToDic(&p, outSize, src, srcLen, finishMode, status);
+  *destLen = p.dicPos;
+  if (res == SZ_OK && *status == LZMA_STATUS_NEEDS_MORE_INPUT)
+    res = SZ_ERROR_INPUT_EOF;
+  LzmaDec_FreeProbs(&p, alloc);
+  return res;
+}

--- a/esurfingclient/main/src/cipher/algo/ios/lzma/LzmaDec.h
+++ b/esurfingclient/main/src/cipher/algo/ios/lzma/LzmaDec.h
@@ -1,0 +1,234 @@
+/* LzmaDec.h -- LZMA Decoder
+2018-04-21 : Igor Pavlov : Public domain */
+
+#ifndef __LZMA_DEC_H
+#define __LZMA_DEC_H
+
+#include "7zTypes.h"
+
+EXTERN_C_BEGIN
+
+/* #define _LZMA_PROB32 */
+/* _LZMA_PROB32 can increase the speed on some CPUs,
+   but memory usage for CLzmaDec::probs will be doubled in that case */
+
+typedef
+#ifdef _LZMA_PROB32
+  UInt32
+#else
+  UInt16
+#endif
+  CLzmaProb;
+
+
+/* ---------- LZMA Properties ---------- */
+
+#define LZMA_PROPS_SIZE 5
+
+typedef struct _CLzmaProps
+{
+  Byte lc;
+  Byte lp;
+  Byte pb;
+  Byte _pad_;
+  UInt32 dicSize;
+} CLzmaProps;
+
+/* LzmaProps_Decode - decodes properties
+Returns:
+  SZ_OK
+  SZ_ERROR_UNSUPPORTED - Unsupported properties
+*/
+
+SRes LzmaProps_Decode(CLzmaProps *p, const Byte *data, unsigned size);
+
+
+/* ---------- LZMA Decoder state ---------- */
+
+/* LZMA_REQUIRED_INPUT_MAX = number of required input bytes for worst case.
+   Num bits = log2((2^11 / 31) ^ 22) + 26 < 134 + 26 = 160; */
+
+#define LZMA_REQUIRED_INPUT_MAX 20
+
+typedef struct
+{
+  /* Don't change this structure. ASM code can use it. */
+  CLzmaProps prop;
+  CLzmaProb *probs;
+  CLzmaProb *probs_1664;
+  Byte *dic;
+  SizeT dicBufSize;
+  SizeT dicPos;
+  const Byte *buf;
+  UInt32 range;
+  UInt32 code;
+  UInt32 processedPos;
+  UInt32 checkDicSize;
+  UInt32 reps[4];
+  UInt32 state;
+  UInt32 remainLen;
+
+  UInt32 numProbs;
+  unsigned tempBufSize;
+  Byte tempBuf[LZMA_REQUIRED_INPUT_MAX];
+} CLzmaDec;
+
+#define LzmaDec_Construct(p) { (p)->dic = NULL; (p)->probs = NULL; }
+
+void LzmaDec_Init(CLzmaDec *p);
+
+/* There are two types of LZMA streams:
+     - Stream with end mark. That end mark adds about 6 bytes to compressed size.
+     - Stream without end mark. You must know exact uncompressed size to decompress such stream. */
+
+typedef enum
+{
+  LZMA_FINISH_ANY,   /* finish at any point */
+  LZMA_FINISH_END    /* block must be finished at the end */
+} ELzmaFinishMode;
+
+/* ELzmaFinishMode has meaning only if the decoding reaches output limit !!!
+
+   You must use LZMA_FINISH_END, when you know that current output buffer
+   covers last bytes of block. In other cases you must use LZMA_FINISH_ANY.
+
+   If LZMA decoder sees end marker before reaching output limit, it returns SZ_OK,
+   and output value of destLen will be less than output buffer size limit.
+   You can check status result also.
+
+   You can use multiple checks to test data integrity after full decompression:
+     1) Check Result and "status" variable.
+     2) Check that output(destLen) = uncompressedSize, if you know real uncompressedSize.
+     3) Check that output(srcLen) = compressedSize, if you know real compressedSize.
+        You must use correct finish mode in that case. */
+
+typedef enum
+{
+  LZMA_STATUS_NOT_SPECIFIED,               /* use main error code instead */
+  LZMA_STATUS_FINISHED_WITH_MARK,          /* stream was finished with end mark. */
+  LZMA_STATUS_NOT_FINISHED,                /* stream was not finished */
+  LZMA_STATUS_NEEDS_MORE_INPUT,            /* you must provide more input bytes */
+  LZMA_STATUS_MAYBE_FINISHED_WITHOUT_MARK  /* there is probability that stream was finished without end mark */
+} ELzmaStatus;
+
+/* ELzmaStatus is used only as output value for function call */
+
+
+/* ---------- Interfaces ---------- */
+
+/* There are 3 levels of interfaces:
+     1) Dictionary Interface
+     2) Buffer Interface
+     3) One Call Interface
+   You can select any of these interfaces, but don't mix functions from different
+   groups for same object. */
+
+
+/* There are two variants to allocate state for Dictionary Interface:
+     1) LzmaDec_Allocate / LzmaDec_Free
+     2) LzmaDec_AllocateProbs / LzmaDec_FreeProbs
+   You can use variant 2, if you set dictionary buffer manually.
+   For Buffer Interface you must always use variant 1.
+
+LzmaDec_Allocate* can return:
+  SZ_OK
+  SZ_ERROR_MEM         - Memory allocation error
+  SZ_ERROR_UNSUPPORTED - Unsupported properties
+*/
+   
+SRes LzmaDec_AllocateProbs(CLzmaDec *p, const Byte *props, unsigned propsSize, ISzAllocPtr alloc);
+void LzmaDec_FreeProbs(CLzmaDec *p, ISzAllocPtr alloc);
+
+SRes LzmaDec_Allocate(CLzmaDec *p, const Byte *props, unsigned propsSize, ISzAllocPtr alloc);
+void LzmaDec_Free(CLzmaDec *p, ISzAllocPtr alloc);
+
+/* ---------- Dictionary Interface ---------- */
+
+/* You can use it, if you want to eliminate the overhead for data copying from
+   dictionary to some other external buffer.
+   You must work with CLzmaDec variables directly in this interface.
+
+   STEPS:
+     LzmaDec_Construct()
+     LzmaDec_Allocate()
+     for (each new stream)
+     {
+       LzmaDec_Init()
+       while (it needs more decompression)
+       {
+         LzmaDec_DecodeToDic()
+         use data from CLzmaDec::dic and update CLzmaDec::dicPos
+       }
+     }
+     LzmaDec_Free()
+*/
+
+/* LzmaDec_DecodeToDic
+   
+   The decoding to internal dictionary buffer (CLzmaDec::dic).
+   You must manually update CLzmaDec::dicPos, if it reaches CLzmaDec::dicBufSize !!!
+
+finishMode:
+  It has meaning only if the decoding reaches output limit (dicLimit).
+  LZMA_FINISH_ANY - Decode just dicLimit bytes.
+  LZMA_FINISH_END - Stream must be finished after dicLimit.
+
+Returns:
+  SZ_OK
+    status:
+      LZMA_STATUS_FINISHED_WITH_MARK
+      LZMA_STATUS_NOT_FINISHED
+      LZMA_STATUS_NEEDS_MORE_INPUT
+      LZMA_STATUS_MAYBE_FINISHED_WITHOUT_MARK
+  SZ_ERROR_DATA - Data error
+*/
+
+SRes LzmaDec_DecodeToDic(CLzmaDec *p, SizeT dicLimit,
+    const Byte *src, SizeT *srcLen, ELzmaFinishMode finishMode, ELzmaStatus *status);
+
+
+/* ---------- Buffer Interface ---------- */
+
+/* It's zlib-like interface.
+   See LzmaDec_DecodeToDic description for information about STEPS and return results,
+   but you must use LzmaDec_DecodeToBuf instead of LzmaDec_DecodeToDic and you don't need
+   to work with CLzmaDec variables manually.
+
+finishMode:
+  It has meaning only if the decoding reaches output limit (*destLen).
+  LZMA_FINISH_ANY - Decode just destLen bytes.
+  LZMA_FINISH_END - Stream must be finished after (*destLen).
+*/
+
+SRes LzmaDec_DecodeToBuf(CLzmaDec *p, Byte *dest, SizeT *destLen,
+    const Byte *src, SizeT *srcLen, ELzmaFinishMode finishMode, ELzmaStatus *status);
+
+
+/* ---------- One Call Interface ---------- */
+
+/* LzmaDecode
+
+finishMode:
+  It has meaning only if the decoding reaches output limit (*destLen).
+  LZMA_FINISH_ANY - Decode just destLen bytes.
+  LZMA_FINISH_END - Stream must be finished after (*destLen).
+
+Returns:
+  SZ_OK
+    status:
+      LZMA_STATUS_FINISHED_WITH_MARK
+      LZMA_STATUS_NOT_FINISHED
+      LZMA_STATUS_MAYBE_FINISHED_WITHOUT_MARK
+  SZ_ERROR_DATA - Data error
+  SZ_ERROR_MEM  - Memory allocation error
+  SZ_ERROR_UNSUPPORTED - Unsupported properties
+  SZ_ERROR_INPUT_EOF - It needs more bytes in input buffer (src).
+*/
+
+SRes LzmaDecode(Byte *dest, SizeT *destLen, const Byte *src, SizeT *srcLen,
+    const Byte *propData, unsigned propSize, ELzmaFinishMode finishMode,
+    ELzmaStatus *status, ISzAllocPtr alloc);
+
+EXTERN_C_END
+
+#endif

--- a/esurfingclient/main/src/cipher/algo/ios/lzma/Precomp.h
+++ b/esurfingclient/main/src/cipher/algo/ios/lzma/Precomp.h
@@ -1,0 +1,4 @@
+/* Minimal stub so vendored LZMA SDK sources compile without the rest of 7-Zip. */
+#ifndef ESURFING_LZMA_PRECOMP_H
+#define ESURFING_LZMA_PRECOMP_H
+#endif

--- a/esurfingclient/main/src/utils/PlatformUtils.c
+++ b/esurfingclient/main/src/utils/PlatformUtils.c
@@ -34,6 +34,7 @@ static char config_file[PATH_MAX + 1 + sizeof(DIALER_CONFIG_FILE)];
 #define OLD_ANDROID_UA "CCTP/android64_vpn/2093"
 #define ANDROID_UA "CCTP/android11_64/2104"
 #define IOS_UA "CCTP/iOSdy/4023"
+#define MACOS_UA "CCTP/macdy/5019"
 
 static bool channel_str_eq(const char* a, const char* b)
 {
@@ -55,7 +56,7 @@ static uint8_t parse_channel_json(const cJSON* chn, uint8_t cfg_no)
     if (cJSON_IsNumber(chn))
     {
         const int value = chn->valueint;
-        if (value >= 1 && value <= 4)
+        if (value >= 1 && value <= 5)
         {
             return (uint8_t)value;
         }
@@ -82,6 +83,10 @@ static uint8_t parse_channel_json(const cJSON* chn, uint8_t cfg_no)
         {
             return 4;
         }
+        if (channel_str_eq(value, "macos") || channel_str_eq(value, "mac") || channel_str_eq(value, "osx") || channel_str_eq(value, "5"))
+        {
+            return 5;
+        }
     }
 
     LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", cfg_no);
@@ -107,6 +112,10 @@ static void apply_channel_ua(login_cfg_t* cfg, uint8_t cfg_no)
     case 4:
         LOG_INFO("使用通道: iOS");
         snprintf(cfg->user_agent, USER_AGENT_LEN, IOS_UA);
+        break;
+    case 5:
+        LOG_INFO("使用通道: macOS");
+        snprintf(cfg->user_agent, USER_AGENT_LEN, MACOS_UA);
         break;
     default:
         LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", cfg_no);

--- a/esurfingclient/main/src/utils/PlatformUtils.c
+++ b/esurfingclient/main/src/utils/PlatformUtils.c
@@ -11,6 +11,9 @@
 #include <errno.h>
 #include <stdio.h>
 #include <time.h>
+#ifndef _WIN32
+#include <strings.h>
+#endif
 
 #ifdef _WIN32
 
@@ -30,6 +33,88 @@ static char config_file[PATH_MAX + 1 + sizeof(DIALER_CONFIG_FILE)];
 #define LINUX_UA "CCTP/Linux64/1003"
 #define OLD_ANDROID_UA "CCTP/android64_vpn/2093"
 #define ANDROID_UA "CCTP/android11_64/2104"
+#define IOS_UA "CCTP/iOSdy/4023"
+
+static bool channel_str_eq(const char* a, const char* b)
+{
+#ifdef _WIN32
+    return _stricmp(a, b) == 0;
+#else
+    return strcasecmp(a, b) == 0;
+#endif
+}
+
+static uint8_t parse_channel_json(const cJSON* chn, uint8_t cfg_no)
+{
+    if (chn == NULL)
+    {
+        LOG_WARN("配置 %" PRIu8 " channel 参数不存在, 使用默认通道 (Android)", cfg_no);
+        return 3;
+    }
+
+    if (cJSON_IsNumber(chn))
+    {
+        const int value = chn->valueint;
+        if (value >= 1 && value <= 4)
+        {
+            return (uint8_t)value;
+        }
+        LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", cfg_no);
+        return 3;
+    }
+
+    if (cJSON_IsString(chn) && chn->valuestring != NULL)
+    {
+        const char* value = chn->valuestring;
+        if (channel_str_eq(value, "windows") || channel_str_eq(value, "1"))
+        {
+            return 1;
+        }
+        if (channel_str_eq(value, "linux") || channel_str_eq(value, "pc") || channel_str_eq(value, "2"))
+        {
+            return 2;
+        }
+        if (channel_str_eq(value, "android") || channel_str_eq(value, "phone") || channel_str_eq(value, "3"))
+        {
+            return 3;
+        }
+        if (channel_str_eq(value, "ios") || channel_str_eq(value, "iphone") || channel_str_eq(value, "4"))
+        {
+            return 4;
+        }
+    }
+
+    LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", cfg_no);
+    return 3;
+}
+
+static void apply_channel_ua(login_cfg_t* cfg, uint8_t cfg_no)
+{
+    switch (cfg->chn)
+    {
+    case 1:
+        LOG_INFO("使用通道: Windows (暂未实现, 使用 Android 通道)");
+        snprintf(cfg->user_agent, USER_AGENT_LEN, ANDROID_UA);
+        break;
+    case 2:
+        LOG_INFO("使用通道: Linux");
+        snprintf(cfg->user_agent, USER_AGENT_LEN, LINUX_UA);
+        break;
+    case 3:
+        LOG_INFO("使用通道: Android");
+        snprintf(cfg->user_agent, USER_AGENT_LEN, ANDROID_UA);
+        break;
+    case 4:
+        LOG_INFO("使用通道: iOS");
+        snprintf(cfg->user_agent, USER_AGENT_LEN, IOS_UA);
+        break;
+    default:
+        LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", cfg_no);
+        cfg->chn = 3;
+        snprintf(cfg->user_agent, USER_AGENT_LEN, ANDROID_UA);
+        break;
+    }
+}
 
 typedef struct
 {
@@ -387,7 +472,7 @@ char* create_xml_payload(const XmlChoose choose)
             safe_str(g_prog_status[tl_thread_idx].auth_cfg.host_name),
             safe_str(g_prog_status[tl_thread_idx].auth_cfg.client_ip),
             safe_str(g_prog_status[tl_thread_idx].auth_cfg.mac_addr),
-            safe_str(g_prog_status[tl_thread_idx].auth_cfg.host_name),
+            safe_str(g_prog_status[tl_thread_idx].auth_cfg.ostag),
             safe_str(g_prog_status[tl_thread_idx].auth_cfg.ac_ip)
         );
         break;
@@ -432,7 +517,7 @@ char* create_xml_payload(const XmlChoose choose)
             safe_str(g_prog_status[tl_thread_idx].auth_cfg.client_ip),
             safe_str(g_prog_status[tl_thread_idx].auth_cfg.ticket),
             safe_str(g_prog_status[tl_thread_idx].auth_cfg.mac_addr),
-            safe_str(g_prog_status[tl_thread_idx].auth_cfg.host_name)
+            safe_str(g_prog_status[tl_thread_idx].auth_cfg.ostag)
         );
         break;
     default:
@@ -522,7 +607,8 @@ bool save_cfg(char* configs_str)
     set_logger_level(log_lv->valueint);
     snprintf(g_prog_status[0].login_cfg.usr, USR_LEN, "%s", username->valuestring);
     snprintf(g_prog_status[0].login_cfg.pwd, PWD_LEN, "%s", password->valuestring);
-    g_prog_status[0].login_cfg.chn = channel->valueint;
+    g_prog_status[0].login_cfg.chn = parse_channel_json(channel, 1);
+    apply_channel_ua(&g_prog_status[0].login_cfg, 1);
 
     cJSON_Delete(configs);
 
@@ -716,44 +802,8 @@ bool load_cfg()
         snprintf(g_prog_status[valid_i].login_cfg.usr, USR_LEN, "%s", safe_str(usr->valuestring));
         snprintf(g_prog_status[valid_i].login_cfg.pwd, PWD_LEN, "%s", safe_str(pwd->valuestring));
 
-        // 检查通道
-        if (chn == NULL)
-        {
-            LOG_WARN("配置 %" PRIu8 " channel 参数不存在, 使用默认通道", i + 1);
-            g_prog_status[valid_i].login_cfg.chn = 3;
-        }
-        else
-        {
-            if (cJSON_IsNumber(chn))
-            {
-                g_prog_status[valid_i].login_cfg.chn = chn->valueint;
-            }
-            else
-            {
-                LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道", i + 1);
-                g_prog_status[valid_i].login_cfg.chn = 3;
-            }
-        }
-
-        // 转化成 UA
-        switch (g_prog_status[valid_i].login_cfg.chn)
-        {
-        case 1:
-            LOG_INFO("使用通道: Windows (暂未实现, 使用 Android 通道)");
-            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
-            break;
-        case 2:
-            LOG_INFO("使用通道: Linux");
-            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, LINUX_UA);
-            break;
-        case 3:
-            LOG_INFO("使用通道: Android");
-            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
-            break;
-        default:
-            LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", i + 1);
-            snprintf(g_prog_status[valid_i].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
-        }
+        g_prog_status[valid_i].login_cfg.chn = parse_channel_json(chn, i + 1);
+        apply_channel_ua(&g_prog_status[valid_i].login_cfg, i + 1);
 
         LOG_DEBUG("使用 UA: %s", g_prog_status[valid_i].login_cfg.user_agent);
         LOG_DEBUG("当前使用下标: %" PRIu8, valid_i);
@@ -840,44 +890,8 @@ bool load_cfg()
         snprintf(g_prog_status[0].login_cfg.usr, USR_LEN, "%s", safe_str(usr->valuestring));
         snprintf(g_prog_status[0].login_cfg.pwd, PWD_LEN, "%s", safe_str(pwd->valuestring));
 
-        // 检查通道
-        if (chn == NULL)
-        {
-            LOG_WARN("配置 %" PRIu8 " channel 参数不存在, 使用默认通道 (Android)", i + 1);
-            g_prog_status[0].login_cfg.chn = 3;
-        }
-        else
-        {
-            if (cJSON_IsNumber(chn))
-            {
-                g_prog_status[0].login_cfg.chn = chn->valueint;
-            }
-            else
-            {
-                LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", i + 1);
-                g_prog_status[0].login_cfg.chn = 3;
-            }
-        }
-
-        // 转化成 UA
-        switch (g_prog_status[0].login_cfg.chn)
-        {
-        case 1:
-            LOG_INFO("使用通道: Windows (暂未实现, 使用 Android 通道)");
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
-            break;
-        case 2:
-            LOG_INFO("使用通道: Linux");
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, LINUX_UA);
-            break;
-        case 3:
-            LOG_INFO("使用通道: Android");
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
-            break;
-        default:
-            LOG_WARN("配置 %" PRIu8 " channel 参数错误, 使用默认通道 (Android)", i + 1);
-            snprintf(g_prog_status[0].login_cfg.user_agent, USER_AGENT_LEN, ANDROID_UA);
-        }
+        g_prog_status[0].login_cfg.chn = parse_channel_json(chn, i + 1);
+        apply_channel_ua(&g_prog_status[0].login_cfg, i + 1);
 
         LOG_DEBUG("使用 UA: %s", g_prog_status[0].login_cfg.user_agent);
         LOG_DEBUG("当前使用下标: 0");

--- a/esurfingclient/main/src/webserver/WebServer.c
+++ b/esurfingclient/main/src/webserver/WebServer.c
@@ -63,7 +63,22 @@ static void fn(struct mg_connection *c, const int ev, void *ev_data)
 
                 cJSON_AddStringToObject(account, "username", g_prog_status[0].login_cfg.usr);
                 cJSON_AddStringToObject(account, "password", g_prog_status[0].login_cfg.pwd);
-                cJSON_AddNumberToObject(account, "channel", g_prog_status[0].login_cfg.chn);
+                {
+                    const char* channel_name = "phone";
+                    switch (g_prog_status[0].login_cfg.chn)
+                    {
+                    case 2:
+                        channel_name = "pc";
+                        break;
+                    case 4:
+                        channel_name = "ios";
+                        break;
+                    default:
+                        channel_name = "phone";
+                        break;
+                    }
+                    cJSON_AddStringToObject(account, "channel", channel_name);
+                }
 
                 cJSON_AddItemToArray(accounts, account);
                 cJSON_AddItemToObject(configs, "accounts", accounts);

--- a/esurfingclient/main/src/webserver/WebServer.c
+++ b/esurfingclient/main/src/webserver/WebServer.c
@@ -73,6 +73,9 @@ static void fn(struct mg_connection *c, const int ev, void *ev_data)
                     case 4:
                         channel_name = "ios";
                         break;
+                    case 5:
+                        channel_name = "macos";
+                        break;
                     default:
                         channel_name = "phone";
                         break;

--- a/luci-app-esurfingclient/legacy-luci/usr/lib/lua/luci/view/esurfingclient.htm
+++ b/luci-app-esurfingclient/legacy-luci/usr/lib/lua/luci/view/esurfingclient.htm
@@ -558,8 +558,16 @@ end
 
         edit_username.value = account.username;
         edit_password.value = account.password;
+        var channel = account.channel;
+        if (channel === 4 || channel === '4' || channel === 'ios' || channel === 'iphone') {
+            channel = 'ios';
+        } else if (channel === 2 || channel === '2' || channel === 'pc' || channel === 'linux') {
+            channel = 'pc';
+        } else {
+            channel = 'phone';
+        }
         for (var i = 0; i < edit_channel.options.length; i++) {
-            if (edit_channel.options[i].value === account.channel) {
+            if (edit_channel.options[i].value === channel) {
                 edit_channel.selectedIndex = i;
                 break;
             }
@@ -694,6 +702,7 @@ end
                     <select id='edit_channel' class='cbi-input-select' name='channel'>
                         <option value='phone'>phone</option>
                         <option value='pc'>pc</option>
+                        <option value='ios'>ios</option>
                     </select>
                     <div class='cbi-value-description'>选择账号的认证通道</div>
                 </div>

--- a/luci-app-esurfingclient/legacy-luci/usr/lib/lua/luci/view/esurfingclient.htm
+++ b/luci-app-esurfingclient/legacy-luci/usr/lib/lua/luci/view/esurfingclient.htm
@@ -559,7 +559,9 @@ end
         edit_username.value = account.username;
         edit_password.value = account.password;
         var channel = account.channel;
-        if (channel === 4 || channel === '4' || channel === 'ios' || channel === 'iphone') {
+        if (channel === 5 || channel === '5' || channel === 'macos' || channel === 'mac' || channel === 'osx') {
+            channel = 'macos';
+        } else if (channel === 4 || channel === '4' || channel === 'ios' || channel === 'iphone') {
             channel = 'ios';
         } else if (channel === 2 || channel === '2' || channel === 'pc' || channel === 'linux') {
             channel = 'pc';
@@ -703,6 +705,7 @@ end
                         <option value='phone'>phone</option>
                         <option value='pc'>pc</option>
                         <option value='ios'>ios</option>
+                        <option value='macos'>macos</option>
                     </select>
                     <div class='cbi-value-description'>选择账号的认证通道</div>
                 </div>

--- a/luci-app-esurfingclient/luci/www/luci-static/resources/view/esurfingclient.js
+++ b/luci-app-esurfingclient/luci/www/luci-static/resources/view/esurfingclient.js
@@ -266,8 +266,9 @@ return view.extend({
                 E('label', { class: 'cbi-value-title', style: 'margin-top: 10px;' }, '*通道'),
                 E('div', { class: 'cbi-value-field' }, [
                     E('select', { id: 'edit_channel', class: 'cbi-input-select' }, [
-                        E('option', { value: 'phone', selected: account.channel === 'phone' ? true : undefined }, 'phone'),
-                        E('option', { value: 'pc', selected: account.channel === 'pc' ? true : undefined }, 'pc')
+                        E('option', { value: 'phone', selected: (account.channel === 'phone' || account.channel === 'android' || account.channel === 3 || account.channel === '3') ? true : undefined }, 'phone'),
+                        E('option', { value: 'pc', selected: (account.channel === 'pc' || account.channel === 'linux' || account.channel === 2 || account.channel === '2') ? true : undefined }, 'pc'),
+                        E('option', { value: 'ios', selected: (account.channel === 'ios' || account.channel === 'iphone' || account.channel === 4 || account.channel === '4') ? true : undefined }, 'ios')
                     ]),
                     E('div', { class: 'cbi-value-description' }, '选择账号的认证通道')
                 ])

--- a/luci-app-esurfingclient/luci/www/luci-static/resources/view/esurfingclient.js
+++ b/luci-app-esurfingclient/luci/www/luci-static/resources/view/esurfingclient.js
@@ -268,7 +268,8 @@ return view.extend({
                     E('select', { id: 'edit_channel', class: 'cbi-input-select' }, [
                         E('option', { value: 'phone', selected: (account.channel === 'phone' || account.channel === 'android' || account.channel === 3 || account.channel === '3') ? true : undefined }, 'phone'),
                         E('option', { value: 'pc', selected: (account.channel === 'pc' || account.channel === 'linux' || account.channel === 2 || account.channel === '2') ? true : undefined }, 'pc'),
-                        E('option', { value: 'ios', selected: (account.channel === 'ios' || account.channel === 'iphone' || account.channel === 4 || account.channel === '4') ? true : undefined }, 'ios')
+                        E('option', { value: 'ios', selected: (account.channel === 'ios' || account.channel === 'iphone' || account.channel === 4 || account.channel === '4') ? true : undefined }, 'ios'),
+                        E('option', { value: 'macos', selected: (account.channel === 'macos' || account.channel === 'mac' || account.channel === 'osx' || account.channel === 5 || account.channel === '5') ? true : undefined }, 'macos')
                     ]),
                     E('div', { class: 'cbi-value-description' }, '选择账号的认证通道')
                 ])


### PR DESCRIPTION
## 概述

增加 `ios` (channel=4) 和 `macos` (channel=5) 通道。两者都按广东天翼校园动态 ZSM 拨号（TEA + LZMA + JS `cdy(codex, …)`）

已在学校环境实测：3 个账号均可拉 ZSM、取 Ticket、登录、心跳

## 行为

### 共用

- 首次拉 ZSM 使用空 POST（`Algo-ID` 为零 UUID）。
- Ticket 返回 TEA + LZMA 动态模块，AID 不在 Android/Linux 硬编码表里。按内容识别 IZsmModLoad。
- JS 模板：`var codex = 0xNN; cdy(codex, …)`。oCode 1–9 复用现有 Android 新算法。

### iOS

- `"channel": "ios"` / `"iphone"` / `4`
- UA `CCTP/iOSdy/4023`，主机名 `iPhone 14`，ostag `iPhone iOS 17.0`

### macOS

- `"channel": "macos"` / `"mac"` / `5`
- UA `CCTP/macdy/5019`（GDCV Info.plist `verno`）
- 主机名 `MacBookPro`，ostag `macOS,14.4`

## LuCI / 桌面 Web

通道下拉增加 `ios`、`macos`。

## 未覆盖

- nCode（type ≥ 16）尚未移植。
- JS 若走 `pxs` / `txs` 而不是 `cdy`，当前只做 cdy 加解密。

## 测试

OpenWrt 多 WAN，三个 **iOS** 账号：

- `codex=0x01` 双层 AES-ECB、`codex=0x05` 三层 TEA-ECB
- 登录成功，Keep-Url / Term-Url 正常
- 心跳 `interval=10800, level=0`